### PR TITLE
Fix CSS Conflict

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -97,7 +97,7 @@
   }
 
   .highlight a,
-  li:hover a {
+  li:hover > a {
     background: #f0f0f0;
     color: #333;
   }


### PR DESCRIPTION
Wrapping this component in an li tag...
```
<li>
    <vue-select></vue-select>
</li>
```
... causes every "<a>" to be highlighted when the root li is hovered over. I fixed this by simply adding a direct child css operator: ">"