### PR TITLE
Blur on select if not multiple.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -314,6 +314,7 @@
       onAfterSelect(option) {
           if (!this.multiple) {
             this.open = !this.open
+            this.$els.search.blur()
           }
 
           if( this.clearSearchOnSelect ) {


### PR DESCRIPTION
Currently, when an item is selected from the list, the select is closed but the text input has focus. This PR simply removes the focus from the input if the selection is not multiple.