### PR TITLE
Use keydown instead of keyup to check maybeDeleteValue

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -136,7 +136,7 @@
           v-el:search
           v-show="searchable"
           v-model="search"
-          @keyup.delete="maybeDeleteValue"
+          @keydown.delete="maybeDeleteValue"
           @keyup.esc="onEscape"
           @keyup.up.prevent="typeAheadUp"
           @keyup.down.prevent="typeAheadDown"


### PR DESCRIPTION
Using keyup causes the previous tag to be removed when deleting a search term.

**Example (ignore the styling)**:


![](http://i.imgur.com/WKE78yn.gif)
