### PR TITLE
Change name from sagalbot/vue-select to vue-select

### DIFF
--- a/src/components/snippets/InstallSnippet.vue
+++ b/src/components/snippets/InstallSnippet.vue
@@ -1,6 +1,6 @@
 <template>
 <p>Install from GitHub via NPM</p>
-      <pre><v-code lang="bash">npm install sagalbot/vue-select</v-code></pre>
+      <pre><v-code lang="bash">npm install vue-select</v-code></pre>
 
       <p>To use the vue-select component in your templates, simply import it, and register it with your component.</p>
 <pre><v-code lang="markup">&#x3C;template&#x3E;


### PR DESCRIPTION
The GitHub Pages website (https://sagalbot.github.io/vue-select/) currently still shows the old name on npm.