### PR TITLE
Fixing a viewport scrollbar bug when the list is loading

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -130,6 +130,7 @@
 		right: 10px;
 		font-size: 5px;
 		text-indent: -9999em;
+		overflow: hidden;
 		border-top: .9em solid rgba(100, 100, 100, .1);
 		border-right: .9em solid rgba(100, 100, 100, .1);
 		border-bottom: .9em solid rgba(100, 100, 100, .1);


### PR DESCRIPTION
The negative text indent will cause the scrollbars to go berserk as the loading text gets rotated around the viewport. Overflow hidden insures the text outside the spinner is not displayed.