### PR TITLE
add cleanValue props

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -362,6 +362,16 @@
 			},
 
 			/**
+			 * Enable/disable clean value when refresh options.
+			 * clean for default
+			 * @type {Boolean}
+			 */
+			clanValue:{
+				type: Boolean,
+				default: true
+			}
+
+			/**
 			 * When true, newly created tags will be added to
 			 * the options list.
 			 * @type {Boolean}
@@ -402,7 +412,7 @@
 				}
 			},
 			options() {
-				if (!this.taggable) {
+				if (this.cleanValue) {
 					this.$set('value', this.multiple ? [] : null)
 				}
 			},


### PR DESCRIPTION
It is crazy for cleaning value when opetions refresh,
why always do that?
when i refreash options,my value always be deleted, so,i add a props cleanValue to manager it