### PR TITLE
Added possibility of changing de message appearing when not finding options

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -217,7 +217,7 @@
 			</li>
 			<li transition="fade" v-if="!filteredOptions.length" class="divider"></li>
 			<li transition="fade" v-if="!filteredOptions.length" class="text-center">
-				<slot name="no-options">Sorry, no matching options.</slot>
+				<slot name="no-options">{{noOptionMsg}}</slot>
 			</li>
 		</ul>
 	</div>
@@ -393,6 +393,15 @@
 				type: Boolean,
 				default: false
 			},
+			
+			/**
+			 * User defined message for when not finding any options
+			 * @type {String}
+			 */
+			noOptionMsg: {
+				type: String,
+				default: 'Sorry, no matching options.'
+			}
 		},
 
 		data() {


### PR DESCRIPTION
Added possibility of changing de message appearing when not finding any option on autocomplete, being default as "Sorry, no matching options.". Can be changed by passing the prop "no-option-msg" on the component.