### PR TITLE
Fixed sintax of example on-change callback

### DIFF
--- a/docs/components/Examples.vue
+++ b/docs/components/Examples.vue
@@ -122,7 +122,7 @@
     </div>
 
     <div class="col-md-6">
-      <pre><v-code lang="markup">&#x3C;v-select on-change=&#x22;consoleCallback&#x22; :options=&#x22;countries&#x22;&#x3E;&#x3C;/v-select&#x3E;</v-code></pre>
+      <pre><v-code lang="markup">&#x3C;v-select :on-change=&#x22;consoleCallback&#x22; :options=&#x22;countries&#x22;&#x3E;&#x3C;/v-select&#x3E;</v-code></pre>
       <pre><v-code lang="javascript">methods: {
   consoleCallback(val) {
     console.dir(JSON.stringify(val))


### PR DESCRIPTION
Following the example of "On-Change Callback" this error was raised 

`[Vue warn]: Invalid prop: type check failed for prop "onChange". Expected Function, got String. (found in component: <v-select>)` 

the prop on-change was without colon  prepended

