### PR TITLE
option and selected-option can be templated

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-runtime"],
+  "plugins": ["transform-runtime", "transform-object-rest-spread"],
   "comments": false
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["es2015", "stage-2"],
-  "plugins": ["transform-runtime", "transform-object-rest-spread"],
+  "plugins": ["transform-runtime"],
   "comments": false
 }

--- a/dev.html
+++ b/dev.html
@@ -39,6 +39,16 @@
         <v-select placeholder="multiple, closeOnSelect=false" multiple :close-on-select="false" :options="['cat', 'dog', 'bear']"></v-select>
         <v-select placeholder="unsearchable" :options="options" :searchable="false"></v-select>
         <v-select placeholder="search github.." label="full_name" @search="search" :options="ajaxRes"></v-select>
+        <v-select placeholder="custom option template" :options="options" multiple>
+            <template slot="selected-option" scope="option">
+                <img :src='"https://www.kidlink.org/icons/f0-" + option.value.toLowerCase() + ".gif"'/> 
+                {{option.label}}
+            </template>
+            <template slot="option" scope="option">
+                <img :src='"https://www.kidlink.org/icons/f0-" + option.value.toLowerCase() + ".gif"'/> 
+                {{option.label}} ({{option.value}})
+            </template>
+        </v-select>
     </div>
 </body>
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -270,7 +270,9 @@
     <div ref="toggle" @mousedown.prevent="toggleDropdown" class="dropdown-toggle">
 
       <span class="selected-tag" v-for="option in valueAsArray" v-bind:key="option.index">
-        {{ getOptionLabel(option) }}
+        <slot name="selected-option" v-bind="option">
+          {{ getOptionLabel(option) }}
+        </slot>
         <button v-if="multiple" @click="deselect(option)" type="button" class="close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -305,7 +307,9 @@
       <ul ref="dropdownMenu" v-if="dropdownOpen" class="dropdown-menu" :style="{ 'max-height': maxHeight }">
         <li v-for="(option, index) in filteredOptions" v-bind:key="index" :class="{ active: isOptionSelected(option), highlight: index === typeAheadPointer }" @mouseover="typeAheadPointer = index">
           <a @mousedown.prevent="select(option)">
+          <slot name="option" v-bind="option">
             {{ getOptionLabel(option) }}
+          </slot>
           </a>
         </li>
         <li v-if="!filteredOptions.length" class="no-options">


### PR DESCRIPTION
Thx for your great implementation!

I have made the following addition so options and selected-options can be templated, which is I think the underlying request of issue #193.

The following example from "dev.html" show a list of countries:
```vue
<v-select placeholder="custom option template" :options="options" multiple>
```
The changes I have made to vue-select make to following possible (showing the flags of the countries):
```vue
<v-select placeholder="custom option template" :options="options" multiple>
  <template slot="selected-option" scope="option">
    <img :src='"https://www.kidlink.org/icons/f0-" + option.value.toLowerCase() + ".gif"'/> 
      {{option.label}}
  </template>
  <template slot="option" scope="option">
    <img :src='"https://www.kidlink.org/icons/f0-" + option.value.toLowerCase() + ".gif"'/> 
      {{option.label}} ({{option.value}})
    </template>
</v-select>
```
(if you happen to have a better link to country flags, just change the urls...)

Best regards,

Edwin
