### PR TITLE
Use aria-label to improve component accessibility

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -271,7 +271,7 @@
 
       <span class="selected-tag" v-for="option in valueAsArray" v-bind:key="option.index">
         {{ getOptionLabel(option) }}
-        <button v-if="multiple" @click="deselect(option)" type="button" class="close">
+        <button v-if="multiple" @click="deselect(option)" type="button" class="close" aria-label="Remove option">
           <span aria-hidden="true">&times;</span>
         </button>
       </span>
@@ -292,6 +292,7 @@
               :readonly="!searchable"
               :style="{ width: isValueEmpty ? '100%' : 'auto' }"
               :id="inputId"
+              aria-label="Search for option"
       >
 
       <i v-if="!noDrop" ref="openIndicator" role="presentation" class="open-indicator"></i>


### PR DESCRIPTION
I used the tool aXe to find accessibility issues on my website. It highlighted two problems with vue-select; the search input field is not labelled and the crosses on the selected options are also not labelled. I added both with aria-label and that fixes all issues aXe could find with vue-select.