### PR TITLE
Prevent submitting inside form

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -283,7 +283,7 @@
               @keyup.esc="onEscape"
               @keydown.up.prevent="typeAheadUp"
               @keydown.down.prevent="typeAheadDown"
-              @keyup.enter.prevent="typeAheadSelect"
+              @keydown.enter.prevent="typeAheadSelect"
               @blur="onSearchBlur"
               @focus="onSearchFocus"
               type="search"


### PR DESCRIPTION
I discovered that when vue-select is inside a form it does not prevent a submit when hitting enter. Having a guess since it prevents on `keyup` instead of `keydown` - As forms submit when pressing enter, not when releasing.