### PR TITLE
Emit 'reset' event on empty search

### DIFF
--- a/src/mixins/ajax.js
+++ b/src/mixins/ajax.js
@@ -39,12 +39,8 @@ module.exports = {
 		 * invoke the onSearch callback.
 		 */
 		search() {
-			if (this.search.length > 0) {
-				this.onSearch(this.search, this.toggleLoading)
-        this.$emit('search', this.search, this.toggleLoading)
-      } else {
-        this.$emit('reset', this.search, this.toggleLoading)
-      }
+			this.onSearch(this.search, this.toggleLoading)
+			this.$emit('search', this.search, this.toggleLoading)
 		},
     /**
 		 * Sync the loading prop with the internal

--- a/src/mixins/ajax.js
+++ b/src/mixins/ajax.js
@@ -42,6 +42,8 @@ module.exports = {
 			if (this.search.length > 0) {
 				this.onSearch(this.search, this.toggleLoading)
         this.$emit('search', this.search, this.toggleLoading)
+      } else {
+        this.$emit('reset', this.search, this.toggleLoading)
       }
 		},
     /**

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1488,6 +1488,28 @@ describe('Select.vue', () => {
       })
     })
 
+    it('should trigger the reset event if the search text is empty', (done) => {
+      const vm = new Vue({
+        template: '<div><v-select ref="select" @reset="foo"></v-select></div>',
+        data: { called: false },
+        methods: {
+          foo(val) {
+            this.called = val
+          }
+        }
+      }).$mount()
+
+      vm.$refs.select.search = 'foo'
+      Vue.nextTick(() => {
+        expect(vm.called).toBe(false)
+        vm.$refs.select.search = ''
+        Vue.nextTick(() => {
+          expect(vm.called).toEqual('')
+          done()
+        })
+      })
+    })
+
 		it('can set loading to false from the onSearch callback', (done) => {
 			const vm = new Vue({
 				template: '<div><v-select loading ref="select" :on-search="foo"></v-select></div>',

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1423,7 +1423,7 @@ describe('Select.vue', () => {
 			})
 		})
 
-		it('should not trigger the onSearch callback if the search text is empty', (done) => {
+		it('should trigger the onSearch callback if the search text is empty', (done) => {
 			const vm = new Vue({
 				template: '<div><v-select ref="select" search="foo" :on-search="foo"></v-select></div>',
 				data: { called: false },
@@ -1439,7 +1439,7 @@ describe('Select.vue', () => {
 				expect(vm.called).toBe(true)
 				vm.$refs.select.search = ''
 				Vue.nextTick(() => {
-					expect(vm.called).toBe(true)
+					expect(vm.called).toBe(false)
 					done()
 				})
 			})
@@ -1466,7 +1466,7 @@ describe('Select.vue', () => {
       })
     })
 
-    it('should not trigger the search event if the search text is empty', (done) => {
+    it('should trigger the search event if the search text is empty', (done) => {
       const vm = new Vue({
         template: '<div><v-select ref="select" search="foo" @search="foo"></v-select></div>',
         data: { called: false },
@@ -1482,29 +1482,7 @@ describe('Select.vue', () => {
         expect(vm.called).toBe(true)
         vm.$refs.select.search = ''
         Vue.nextTick(() => {
-          expect(vm.called).toBe(true)
-          done()
-        })
-      })
-    })
-
-    it('should trigger the reset event if the search text is empty', (done) => {
-      const vm = new Vue({
-        template: '<div><v-select ref="select" @reset="foo"></v-select></div>',
-        data: { called: false },
-        methods: {
-          foo(val) {
-            this.called = val
-          }
-        }
-      }).$mount()
-
-      vm.$refs.select.search = 'foo'
-      Vue.nextTick(() => {
-        expect(vm.called).toBe(false)
-        vm.$refs.select.search = ''
-        Vue.nextTick(() => {
-          expect(vm.called).toEqual('')
+          expect(vm.called).toBe(false)
           done()
         })
       })


### PR DESCRIPTION
I would like a 'reset' event for when the search result is set back to being empty.