### PR TITLE
Initially "Start Searching." <= "Sorry, no match*"

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -309,8 +309,11 @@
             {{ getOptionLabel(option) }}
           </a>
         </li>
-        <li v-if="!filteredOptions.length" class="no-options">
+        <li v-if="!filteredOptions.length && search" class="no-options">
           <slot name="no-options">Sorry, no matching options.</slot>
+        </li>
+        <li v-if="!filteredOptions.length && !search" class="no-options">
+          <slot name="no-options">Start Searching...</slot>
         </li>
       </ul>
     </transition>


### PR DESCRIPTION
When we click on input box of vue-select it always say "Sorry, no matching options"... whereas there is no value in the input box to say this statement it should say "Start Searching...". So, from in the tag commit I have changed the text from "Sorry, no matching options" to "Start Searching..." in case there is no value in input box