### PR TITLE
Fix bug if the option label is number.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -848,9 +848,15 @@
       filteredOptions() {
         let options = this.mutableOptions.filter((option) => {
           if (typeof option === 'object' && option.hasOwnProperty(this.label)) {
+            if(typeof option[this.label] === 'number') {
+              return option[this.label].toString().indexOf(this.search) > -1
+            }
             return option[this.label].toLowerCase().indexOf(this.search.toLowerCase()) > -1
           } else if (typeof option === 'object' && !option.hasOwnProperty(this.label)) {
             return console.warn(`[vue-select warn]: Label key "option.${this.label}" does not exist in options object.\nhttp://sagalbot.github.io/vue-select/#ex-labels`)
+          }
+          if(typeof option === 'number') {
+            return option.toString().indexOf(this.search) > -1
           }
           return option.toLowerCase().indexOf(this.search.toLowerCase()) > -1
         })


### PR DESCRIPTION
I met this bug when the `typeof` my label is `number`, as there is no `toLowerCase()` method on `NumberObject`.
```
[Vue warn]: Error in getter for watcher "filteredOptions": "TypeError: e[t.label].toLowerCase is not a function"
```