### PR TITLE
remove old browserify configuration (fixes #173)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,6 @@
     "test": "karma start test/unit/karma.conf.js --single-run",
     "test-watch": "karma start test/unit/karma.conf.js --single-run=false --auto-watch=true"
   },
-  "browserify": {
-    "transform": [
-      "vueify",
-      "babelify"
-    ]
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/sagalbot/vue-select.git"


### PR DESCRIPTION
Now that vue-select uses webpack for bundling, this browserify config is not needed and actually causes problems for browserify users.