### PR TITLE
Add a higher level slot to labels so they can be customised completely

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -282,14 +282,17 @@
   <div :dir="dir" class="dropdown v-select" :class="dropdownClasses">
     <div ref="toggle" @mousedown.prevent="toggleDropdown" :class="['dropdown-toggle', 'clearfix', {'disabled': disabled}]">
 
-      <span class="selected-tag" v-for="option in valueAsArray" v-bind:key="option.index">
-        <slot name="selected-option" v-bind="option">
-          {{ getOptionLabel(option) }}
-        </slot>
-        <button v-if="multiple" @click="deselect(option)" type="button" class="close" aria-label="Remove option">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </span>
+      <slot v-for="option in valueAsArray" name="selected-option-container"
+            :option="option" :deselect="deselect">
+        <span class="selected-tag" v-bind:key="option.index">
+          <slot name="selected-option" v-bind="option">
+            {{ getOptionLabel(option) }}
+          </slot>
+          <button v-if="multiple" @click="deselect(option)" type="button" class="close" aria-label="Remove option">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </span>
+    </slot>
 
       <input
               ref="search"


### PR DESCRIPTION
As discussed in #349, it would be very nice if labels can be customised. My use-case was to give a colour to certain tags to aid visual identification, but a more generic customisation system is probably better to fit everyone's use-case and to not make vue-select too complex.

This PR adds a higher level slot to the labels so that the developer can replace them completely with what they want. So adding a colour to labels is easy, but you could even do something very extravagant if you want to. The already existing slots are not touched to be compatible.

In my case, I replace the label and add a colour in this way:

```HTML
<span slot="selected-option-container"
      slot-scope="props"
      v-bind:key="props.option.index"
      class="selected-tag"
      :style="{'background-color': props.option.name === 'foo' ? 'red' : 'blue'}">
    {{ props.option.name }}
    <button @click="props.deselect(props.option)" type="button" class="close"
            aria-label="Remove option">
        <span aria-hidden="true">&times;</span>
    </button>
</span>
```

Thanks to @MarZab