### PR TITLE
Replace '.form-control' class with '.v-select-search' class.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -307,7 +307,7 @@
               @blur="onSearchBlur"
               @focus="onSearchFocus"
               type="search"
-              class="form-control"
+              class="v-select-search"
               :disabled="disabled"
               :placeholder="searchPlaceholder"
               :readonly="!searchable"

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -312,6 +312,15 @@ describe('Select.vue', () => {
 			vm.$refs.select.search = 'ba'
 			expect(JSON.stringify(vm.$refs.select.filteredOptions)).toEqual(JSON.stringify([{label: 'Bar', value: 'bar'}, {label: 'Baz', value: 'baz'}]))
 		})
+
+		it('should have a search class name', () => {
+			const vm = new Vue({
+				template: '<div><v-select></v-select></div>',
+				components: {vSelect}
+			}).$mount()
+
+			expect(vm.$el.querySelector('.v-select-search')).not.toBeNull();
+		})
 	})
 
 	describe('Toggling Dropdown', () => {


### PR DESCRIPTION
`.form-control` clashes with the bootstrap styles, which causes unnecessary CSS hacks to get around.

Anyone who is using `vue-select` and relies on this `.form-control` should be aware of this change during an update.