### PR TITLE
Allow onSearch to fire with empty search text string - #240

### DIFF
--- a/src/mixins/ajax.js
+++ b/src/mixins/ajax.js
@@ -29,30 +29,34 @@ module.exports = {
 
 	data() {
 		return {
-      mutableLoading: false
-    }
-	},
-
-	watch: {
-		/**
-		 * If a callback & search text has been provided,
-		 * invoke the onSearch callback.
-		 */
-		search() {
-			if (this.search.length > 0) {
-				this.onSearch(this.search, this.toggleLoading)
-        this.$emit('search', this.search, this.toggleLoading)
-      }
-		},
-    /**
-		 * Sync the loading prop with the internal
-		 * mutable loading value.
-     * @param val
-     */
-		loading(val) {
-			this.mutableLoading = val
+		  mutableLoading: false
 		}
 	},
+
+    watch: {
+        /**
+         * If a callback & search text has been provided,
+         * invoke the onSearch callback.
+         */
+        search() {
+            this.invokeOnSearch()
+        },
+
+		open() {
+        	if (this.open && this.search === '') {
+                this.invokeOnSearch()
+            }
+		},
+
+        /**
+         * Sync the loading prop with the internal
+         * mutable loading value.
+         * @param val
+         */
+        loading(val) {
+            this.mutableLoading = val
+        }
+    },
 
 	methods: {
 		/**
@@ -67,6 +71,11 @@ module.exports = {
 				return this.mutableLoading = !this.mutableLoading
 			}
 			return this.mutableLoading = toggle
+		},
+
+		invokeOnSearch() {
+            this.onSearch(this.search, this.toggleLoading)
+            this.$emit('search', this.search, this.toggleLoading)
 		}
 	}
 }

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1033,26 +1033,25 @@ describe('Select.vue', () => {
 			})
 		})
 
-		it('should not trigger the onSearch callback if the search text is empty', (done) => {
-			const vm = new Vue({
-				template: '<div><v-select ref="select" search="foo" :on-search="foo"></v-select></div>',
-				data: { called: false },
-				methods: {
-					foo(val) {
-						this.called = ! this.called
-					}
-				}
-			}).$mount()
+		it('should trigger the onSearch callback when the dropdown is opened with no search text', (done) => {
+            const vm = new Vue({
+                template: '<div><v-select ref="select" :on-search="foo"></v-select></div>',
+                data: {
+                    called: false
+                },
+                methods: {
+                    foo(val) {
+                        this.called = val
+                    }
+                }
+            }).$mount()
 
-			vm.$refs.select.search = 'foo'
-			Vue.nextTick(() => {
-				expect(vm.called).toBe(true)
-				vm.$refs.select.search = ''
-				Vue.nextTick(() => {
-					expect(vm.called).toBe(true)
-					done()
-				})
-			})
+            vm.$refs.select.open = true
+
+            Vue.nextTick(() => {
+                expect(vm.called).toEqual('')
+                done()
+            })
 		})
 
     it('should trigger the search event when the search text changes', (done) => {
@@ -1076,26 +1075,25 @@ describe('Select.vue', () => {
       })
     })
 
-    it('should not trigger the search event if the search text is empty', (done) => {
-      const vm = new Vue({
-        template: '<div><v-select ref="select" search="foo" @search="foo"></v-select></div>',
-        data: { called: false },
-        methods: {
-          foo(val) {
-            this.called = ! this.called
-          }
-        }
-      }).$mount()
+    it('should trigger the search event when the dropdown opens with no search text', (done) => {
+        const vm = new Vue({
+            template: '<div><v-select ref="select" @search="foo"></v-select></div>',
+            data: {
+                called: false
+            },
+            methods: {
+                foo(val) {
+                    this.called = val
+                }
+            }
+        }).$mount()
 
-      vm.$refs.select.search = 'foo'
-      Vue.nextTick(() => {
-        expect(vm.called).toBe(true)
-        vm.$refs.select.search = ''
+        vm.$refs.select.open = true
+
         Vue.nextTick(() => {
-          expect(vm.called).toBe(true)
-          done()
+            expect(vm.called).toEqual('')
+            done()
         })
-      })
     })
 
 		it('can set loading to false from the onSearch callback', (done) => {


### PR DESCRIPTION
This should allow the onSearch callback (for remote option loading) to fire even when the search string is empty - see #240 