### PR TITLE
Add clear button to single select

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -23,6 +23,10 @@
   .v-select.rtl .dropdown-menu {
     text-align: right;
   }
+  .v-select.rtl .dropdown-toggle .clear {
+    left: 30px;
+    right: auto;
+  }
   /* Open Indicator */
   .v-select .open-indicator {
     position: absolute;
@@ -80,6 +84,22 @@
     clear: both;
     height: 0;
   }
+
+  /* Clear Button */
+  .v-select .dropdown-toggle .clear {
+    position: absolute;
+    bottom: 7px;
+    right: 30px;
+    font-size: 23px;
+    font-weight: 700;
+    line-height: 1;
+    color: rgba(60, 60, 60, .5);
+    padding: 0;
+    border: 0;
+    background-color: transparent;
+    cursor: pointer;
+  }
+
   /* Dropdown Toggle States */
   .v-select.searchable .dropdown-toggle {
     cursor: text;
@@ -244,6 +264,7 @@
 
   /* Disabled state */
   .v-select.disabled .dropdown-toggle,
+  .v-select.disabled .dropdown-toggle .clear,
   .v-select.disabled .dropdown-toggle input,
   .v-select.disabled .selected-tag .close,
   .v-select.disabled .open-indicator {
@@ -315,6 +336,17 @@
               :id="inputId"
               aria-label="Search for option"
       >
+
+      <button 
+        v-show="showClearButton" 
+        :disabled="disabled" 
+        @click="clearSelection"
+        type="button" 
+        class="clear" 
+        title="Clear selection" 
+      >
+        <span aria-hidden="true">&times;</span>
+      </button>
 
       <i v-if="!noDrop" ref="openIndicator" role="presentation" class="open-indicator"></i>
 
@@ -690,6 +722,14 @@
       },
 
       /**
+       * Clears the currently selected value(s)
+       * @return {void}
+       */
+       clearSelection() {
+         this.mutableValue = this.multiple ? [] : null
+       },
+
+      /**
        * Called from this.select after each selection.
        * @param  {Object|String} option
        * @return {void}
@@ -935,6 +975,14 @@
         }
 
         return []
+      },
+
+      /**
+       * Determines if the clear button should be displayed.
+       * @return {Boolean}
+       */
+      showClearButton() {
+        return !this.multiple && !this.open && this.mutableValue != null
       }
     },
 

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1225,7 +1225,7 @@ describe('Select.vue', () => {
 
 	describe( 'Clear button', () => {
 
-		it( 'should display clear button on single select with a selected value', () => {
+		it( 'should be displayed on single select when value is selected', () => {
 			const VueSelect = Vue.extend( vSelect )
 			const vm = new VueSelect({
 				propsData: {
@@ -1237,7 +1237,7 @@ describe('Select.vue', () => {
 			expect(vm.showClearButton).toEqual(true)
 		})
 
-		it( 'should not display clear button on multiple select', () => {
+		it( 'should not be displayed on multiple select', () => {
 			const VueSelect = Vue.extend( vSelect )
 			const vm = new VueSelect({
 				propsData: {
@@ -1250,7 +1250,7 @@ describe('Select.vue', () => {
 			expect(vm.showClearButton).toEqual(false)
 		})
 
-		it( 'should remove selected value when clear button is clicked', () => {
+		it( 'should remove selected value when clicked', () => {
 			const VueSelect = Vue.extend( vSelect )
 			const vm = new VueSelect({
 				propsData: {
@@ -1262,6 +1262,20 @@ describe('Select.vue', () => {
 			expect(vm.mutableValue).toEqual('foo')
 			vm.$el.querySelector( 'button.clear' ).click()
 			expect(vm.mutableValue).toEqual(null)
+		})
+
+		it( 'should be disabled when component is disabled', () => {
+			const VueSelect = Vue.extend( vSelect )
+			const vm = new VueSelect({
+				propsData: {
+					options: ['foo','bar'],
+					value: 'foo',
+					disabled: true
+				}
+			}).$mount()
+
+			const buttonEl = vm.$el.querySelector( 'button.clear' )
+			expect(buttonEl.disabled).toEqual(true);
 		})
 	
 	});

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1222,4 +1222,47 @@ describe('Select.vue', () => {
 			})
 		})
 	})
+
+	describe( 'Clear button', () => {
+
+		it( 'should display clear button on single select with a selected value', () => {
+			const VueSelect = Vue.extend( vSelect )
+			const vm = new VueSelect({
+				propsData: {
+					options: ['foo','bar'],
+					value: 'foo'
+				}
+			}).$mount()
+
+			expect(vm.showClearButton).toEqual(true)
+		})
+
+		it( 'should not display clear button on multiple select', () => {
+			const VueSelect = Vue.extend( vSelect )
+			const vm = new VueSelect({
+				propsData: {
+					options: ['foo','bar'],
+					value: 'foo',
+					multiple: true
+				}
+			}).$mount()
+
+			expect(vm.showClearButton).toEqual(false)
+		})
+
+		it( 'should remove selected value when clear button is clicked', () => {
+			const VueSelect = Vue.extend( vSelect )
+			const vm = new VueSelect({
+				propsData: {
+					options: ['foo','bar'],
+					value: 'foo'
+				}
+			}).$mount()
+			
+			expect(vm.mutableValue).toEqual('foo')
+			vm.$el.querySelector( 'button.clear' ).click()
+			expect(vm.mutableValue).toEqual(null)
+		})
+	
+	});
 })


### PR DESCRIPTION
Hi Jeff,

This is a work in progress that adds a clear button to a single select to remove the currently selected value.

Still to do:
- Add a prop to turn this feature on & off (defaults to off?)
- Update docs
- Add some tests
- anything else you can think of?

Can you please take a look over and if you're happy I will complete the PR.
