### PR TITLE
Use deep equal in mutableValue

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -594,7 +594,7 @@
         if (this.multiple) {
           this.onChange ? this.onChange(val) : null
         } else {
-          this.onChange && val !== old ? this.onChange(val) : null
+          this.onChange && JSON.stringify(val) !== JSON.stringify(old) ? this.onChange(val) : null
         }
       },
 


### PR DESCRIPTION
Sometimes, `val` & `old` are objects, like `{ label, value }`, `val !== old` is true, but they have same `label` & `value`, this may cause a dead loop.  
It's better to use a deep equal here.