### PR TITLE
Allow the createOption function to reject the new option

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -679,7 +679,9 @@
             option = this.createOption(option)
           }
 
-          if (this.multiple && !this.mutableValue) {
+          if (!option) {
+            // nothing.
+          } else if (this.multiple && !this.mutableValue) {
             this.mutableValue = [option]
           } else if (this.multiple) {
             this.mutableValue.push(option)


### PR DESCRIPTION
I came to a need to block creating of some particular tags so this solution came to my mind.

If user-defined callback `createOption()` returns `null` or `undefined` the option will be rejected / not added. 

