### PR TITLE
Custom Label Slot

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -46,6 +46,19 @@
                 {{option.label}} ({{option.value}})
             </template>
         </v-select>
+        <v-select multiple placeholder="custom label template" :options="options">
+            <span
+                    slot="selected-option-container"
+                    slot-scope="props"
+                    class="selected-tag"
+            >
+                {{ props.option.label }} ({{ props.option.value }})
+              <button v-if="props.multiple" @click="props.deselect(props.option)" type="button" class="close" aria-label="Remove option">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </span>
+        </v-select>
+
         <v-select placeholder="disabled" disabled  value="disabled"></v-select>
         <v-select placeholder="disabled multiple" disabled multiple  :value="['disabled', 'multiple']"></v-select>
         <v-select placeholder="filterable=false, @search=searchPeople" label="first_name" :filterable="false" @search="searchPeople" :options="people"></v-select>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -313,7 +313,7 @@
     <div ref="toggle" @mousedown.prevent="toggleDropdown" :class="['dropdown-toggle', 'clearfix']">
 
       <slot v-for="option in valueAsArray" name="selected-option-container"
-            :option="option" :deselect="deselect">
+            :option="option" :deselect="deselect" :multiple="multiple" :disabled="disabled">
         <span class="selected-tag" v-bind:key="option.index">
           <slot name="selected-option" v-bind="option">
             {{ getOptionLabel(option) }}


### PR DESCRIPTION
Builds on #352 and adds `multiple` and `disabled` into the slot scope. Adds a dev example.

The `selected-option` slot should really be `selected-option-text` which would make `selected-option-container` = `selected-option`. That change would require a major bump up to `v3.0.0`, not sure if it's worth it.

---
- Closes #349 
- Closes #399 