### PR TITLE
dont deselect when clicking selected options

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -7,7 +7,7 @@
     <!--<link href="https://cdnjs.cloudflare.com/ajax/libs/foundation/6.3.1/css/foundation.min.css" rel="stylesheet">-->
     <!--<link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.3.2/css/bulma.min.css" rel="stylesheet">-->
     <!--<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet">-->
-    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.6/css/bootstrap.min.css"> -->
+    <!--<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0/css/bootstrap.min.css">-->
     <style>
         
         #app {
@@ -30,53 +30,53 @@
 <body>
     <div id="app">
         <v-select placeholder="default" :options="options"></v-select>
-        <!--<v-select placeholder="default, RTL" :options="options" dir="rtl"></v-select>-->
-        <!--<v-select placeholder="default, options=[1,5,10]" :options="[1,5,10]"></v-select>-->
-        <!--<v-select placeholder="multiple" multiple :options="options"></v-select>-->
-        <!--<v-select placeholder="multiple, taggable" multiple taggable :options="options" no-drop></v-select>-->
-        <!--<v-select placeholder="multiple, taggable, push-tags" multiple push-tags taggable :options="[{label: 'Foo', value: 'foo'}]"></v-select>-->
-        <!--<v-select placeholder="multiple, closeOnSelect=true" multiple :options="['cat', 'dog', 'bear']"></v-select>-->
-        <!--<v-select placeholder="multiple, closeOnSelect=false" multiple :close-on-select="false" :options="['cat', 'dog', 'bear']"></v-select>-->
-        <!--<v-select placeholder="searchable=false" :options="options" :searchable="false"></v-select>-->
-        <!--<v-select placeholder="search github.." label="full_name" @search="search" :options="ajaxRes"></v-select>-->
-        <!--<v-select placeholder="custom option template" :options="options" multiple>-->
-            <!--<template slot="selected-option" slot-scope="option">-->
-                <!--{{option.label}}-->
-            <!--</template>-->
-            <!--<template slot="option" slot-scope="option">-->
-                <!--{{option.label}} ({{option.value}})-->
-            <!--</template>-->
-        <!--</v-select>-->
-        <!--<v-select placeholder="custom option template for string array" taggable :options="['cat', 'dog', 'bear']" multiple>-->
-            <!--<template slot="selected-option" slot-scope="option">-->
-                <!--{{option.label}}-->
-            <!--</template>-->
-            <!--<template slot="option" slot-scope="option">-->
-                <!--{{option.label}}-->
-            <!--</template>-->
-        <!--</v-select>-->
-        <!--<v-select multiple placeholder="custom label template" :options="options">-->
-            <!--<span-->
-                    <!--slot="selected-option-container"-->
-                    <!--slot-scope="props"-->
-                    <!--class="selected-tag"-->
-            <!--&gt;-->
-                <!--{{ props.option.label }} ({{ props.option.value }})-->
-              <!--<button v-if="props.multiple" @click="props.deselect(props.option)" type="button" class="close" aria-label="Remove option">-->
-                <!--<span aria-hidden="true">&times;</span>-->
-              <!--</button>-->
-            <!--</span>-->
-        <!--</v-select>-->
+        <v-select placeholder="default, RTL" :options="options" dir="rtl"></v-select>
+        <v-select placeholder="default, options=[1,5,10]" :options="[1,5,10]"></v-select>
+        <v-select placeholder="multiple" multiple :options="options"></v-select>
+        <v-select placeholder="multiple, taggable" multiple taggable :options="options" no-drop></v-select>
+        <v-select placeholder="multiple, taggable, push-tags" multiple push-tags taggable :options="[{label: 'Foo', value: 'foo'}]"></v-select>
+        <v-select placeholder="multiple, closeOnSelect=true" multiple :options="['cat', 'dog', 'bear']"></v-select>
+        <v-select placeholder="multiple, closeOnSelect=false" multiple :close-on-select="false" :options="['cat', 'dog', 'bear']"></v-select>
+        <v-select placeholder="searchable=false" :options="options" :searchable="false"></v-select>
+        <v-select placeholder="search github.." label="full_name" @search="search" :options="ajaxRes"></v-select>
+        <v-select placeholder="custom option template" :options="options" multiple>
+            <template slot="selected-option" slot-scope="option">
+                {{option.label}}
+            </template>
+            <template slot="option" slot-scope="option">
+                {{option.label}} ({{option.value}})
+            </template>
+        </v-select>
+        <v-select placeholder="custom option template for string array" taggable :options="['cat', 'dog', 'bear']" multiple>
+            <template slot="selected-option" slot-scope="option">
+                {{option.label}}
+            </template>
+            <template slot="option" slot-scope="option">
+                {{option.label}}
+            </template>
+        </v-select>
+        <v-select multiple placeholder="custom label template" :options="options">
+            <span
+                    slot="selected-option-container"
+                    slot-scope="props"
+                    class="selected-tag"
+            >
+                {{ props.option.label }} ({{ props.option.value }})
+              <button v-if="props.multiple" @click="props.deselect(props.option)" type="button" class="close" aria-label="Remove option">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </span>
+        </v-select>
 
-        <!--<v-select placeholder="disabled" disabled  value="disabled"></v-select>-->
-        <!--<v-select placeholder="disabled multiple" disabled multiple :value="['disabled', 'multiple']"></v-select>-->
-        <!--<v-select placeholder="filterable=false, @search=searchPeople" label="first_name" :filterable="false" @search="searchPeople" :options="people"></v-select>-->
-        <!--<v-select placeholder="filtering with fuse.js" label="title" :options="fuseSearchOptions" :filter="fuseSearch">-->
-            <!--<template slot="option" scope="option">-->
-                <!--<strong>{{ option.title }}</strong><br>-->
-                <!--<em>{{ `${option.author.firstName} ${option.author.lastName}` }}</em>-->
-            <!--</template>-->
-        <!--</v-select>-->
+        <v-select placeholder="disabled" disabled  value="disabled"></v-select>
+        <v-select placeholder="disabled multiple" disabled multiple :value="['disabled', 'multiple']"></v-select>
+        <v-select placeholder="filterable=false, @search=searchPeople" label="first_name" :filterable="false" @search="searchPeople" :options="people"></v-select>
+        <v-select placeholder="filtering with fuse.js" label="title" :options="fuseSearchOptions" :filter="fuseSearch">
+            <template slot="option" scope="option">
+                <strong>{{ option.title }}</strong><br>
+                <em>{{ `${option.author.firstName} ${option.author.lastName}` }}</em>
+            </template>
+        </v-select>
     </div>
 </body>
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -759,9 +759,7 @@
        * @return {void}
        */
       select(option) {
-        if (this.isOptionSelected(option)) {
-          this.deselect(option)
-        } else {
+        if (!this.isOptionSelected(option)) {
           if (this.taggable && !this.optionExists(option)) {
             option = this.createOption(option)
           }
@@ -802,9 +800,9 @@
        * Clears the currently selected value(s)
        * @return {void}
        */
-       clearSelection() {
-         this.mutableValue = this.multiple ? [] : null
-       },
+      clearSelection() {
+        this.mutableValue = this.multiple ? [] : null
+      },
 
       /**
        * Called from this.select after each selection.

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -117,7 +117,7 @@ describe('Select.vue', () => {
 					options: [{label: 'This is Foo', value: 'foo'}, {label: 'This is Bar', value: 'bar'}]
 				}
 			}).$mount()
-			vm.$children[0].select({label: 'This is Foo', value: 'foo'})
+			vm.$children[0].deselect({label: 'This is Foo', value: 'foo'})
 			expect(vm.$children[0].mutableValue.length).toEqual(1)
 		})
 
@@ -129,7 +129,7 @@ describe('Select.vue', () => {
 					options: ['foo','bar']
 				}
 			}).$mount()
-			vm.$children[0].select('foo')
+			vm.$children[0].deselect('foo')
 			expect(vm.$children[0].mutableValue.length).toEqual(1)
 		}),
 
@@ -1090,7 +1090,7 @@ describe('Select.vue', () => {
 					vm.$refs.select.search = 'one'
 					searchSubmit(vm)
 					Vue.nextTick(() => {
-						expect(vm.$refs.select.mutableValue).toEqual([])
+						expect(vm.$refs.select.mutableValue).toEqual(['one'])
 						expect(vm.$refs.select.search).toEqual('')
 						done()
 					})
@@ -1109,7 +1109,7 @@ describe('Select.vue', () => {
 					vm.$refs.select.search = 'one'
 					searchSubmit(vm)
 					Vue.nextTick(() => {
-						expect(vm.$refs.select.mutableValue).toEqual([])
+						expect(vm.$refs.select.mutableValue).toEqual(['one'])
 						expect(vm.$refs.select.search).toEqual('')
 						done()
 					})


### PR DESCRIPTION
Changes behavior so that clicking an item in the dropdown is only for selection - it will never deselect an item. `multiple` selects have clear buttons for each tag, and `single` selects have the clear button.

The html `<select>` does not deselect values when clicking the same option, `vue-select` shouldn't either.

---

> Thanks to @msyesyan for filing the issue and the original PR #194. I would have merged that branch now, but there were a lot of conflicts and I wanted to get this done quickly after holding off for so long. 

Closes #180 
Closes #194 (duplicate)