### PR TITLE
Disable browser autocomplete FIX

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -336,7 +336,7 @@
               @focus="onSearchFocus"
               type="search"
               class="form-control"
-              autocomplete="false"
+              autocomplete="off"
               :disabled="disabled"
               :placeholder="searchPlaceholder"
               :tabindex="tabindex"


### PR DESCRIPTION
The autocomplete attribute value `"false"` does not exists there are only two options `"on"` or `"off"`
**Syntax:** `<input autocomplete="on|off">`