### PR TITLE
Fix for #430 Narrow Select Width Display Bug

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -341,7 +341,7 @@
               :placeholder="searchPlaceholder"
               :tabindex="tabindex"
               :readonly="!searchable"
-              :style="{ width: isValueEmpty ? '100%' : 'auto' }"
+              :style="{ width: isValueEmpty ? '100%' : '1px' }"
               :id="inputId"
               aria-label="Search for option"
       >

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -141,7 +141,7 @@
     background-color: #f0f0f0;
     border: 1px solid #ccc;
     border-radius: 4px;
-    height: 26px;
+    min-height: 26px;
     margin: 4px 1px 0px 3px;
     padding: 1px 0.25em;
     float: left;


### PR DESCRIPTION
Fixes a display bug I encountered in my project where I had long options on a narrow select width. With this, the premature wrapping to the next line as well as the height restricted silver background on a selected tag is fixed.