### PR TITLE
Fixing unexpected linebreak on single selects

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -215,7 +215,8 @@
     cursor: pointer;
   }
   .v-select input[type="search"].hidden {
-    display: none;
+    width: 0px;
+    padding: 0;
   }
   .v-select input[type="search"].shrunk {
     width: auto;
@@ -989,7 +990,7 @@
        */
       inputClasses() {
         return {
-          hidden: !this.multiple && !this.isValueEmpty,
+          hidden: !this.multiple && !this.isValueEmpty && !this.dropdownOpen,
           shrunk: this.multiple && !this.isValueEmpty,
           empty: this.isValueEmpty,
         }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -73,6 +73,7 @@
     padding: 0;
     background: none;
     border: 1px solid rgba(60, 60, 60, .26);
+    min-height: 36px;
     border-radius: 4px;
     white-space: normal;
   }
@@ -213,6 +214,16 @@
   .v-select.unsearchable input[type="search"]:hover {
     cursor: pointer;
   }
+  .v-select input[type="search"].hidden {
+    display: none;
+  }
+  .v-select input[type="search"].shrunk {
+    width: auto;
+  }
+  .v-select input[type="search"].empty {
+    width: 100%;
+  }
+
     /* List Items */
   .v-select li {
     line-height: 1.42857143; /* Normalize line height */
@@ -336,12 +347,12 @@
               @focus="onSearchFocus"
               type="search"
               class="form-control"
+              :class="inputClasses"
               autocomplete="off"
               :disabled="disabled"
               :placeholder="searchPlaceholder"
               :tabindex="tabindex"
               :readonly="!searchable"
-              :style="{ width: isValueEmpty ? '100%' : 'auto' }"
               :id="inputId"
               aria-label="Search for option"
       >
@@ -969,6 +980,18 @@
           loading: this.mutableLoading,
           rtl: this.dir === 'rtl',
           disabled: this.disabled
+        }
+      },
+
+      /**
+       * Classes to be output on input.form-control
+       * @return {Object}
+       */
+      inputClasses() {
+        return {
+          hidden: !this.multiple && !this.isValueEmpty,
+          shrunk: this.multiple && !this.isValueEmpty,
+          empty: this.isValueEmpty,
         }
       },
 

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1377,6 +1377,28 @@ describe('Select.vue', () => {
       expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
     })
 
+
+    it('should not apply the "hidden" class to the search input when a value is present, and the dropdown is open', () => {
+      const vm = new Vue({
+        template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
+        data: {
+          value: 'one',
+          options: ['one', 'two', 'three'],
+          open: true
+        }
+      }).$mount()
+      vm.$children[0].toggleDropdown({target: vm.$children[0].$refs.search})
+      Vue.nextTick(() => {
+        Vue.nextTick(() => {
+          expect(vm.$children[0].open).toEqual(true)
+          expect(vm.$children[0].inputClasses.hidden).toEqual(false)
+          expect(vm.$children[0].inputClasses.empty).toEqual(false)
+          expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
+          done()
+        })
+      })
+    })
+
 		it ('should not reset the search input on focus lost when clearSearchOnSelect is false', (done) => {
 			const vm = new Vue({
 				template: '<div><v-select ref="select" :options="options" :value="value" :clear-search-on-select="false"></v-select></div>',

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -249,6 +249,36 @@ describe('Select.vue', () => {
 			expect(vm.$children[0].isOptionSelected('foo')).toEqual(true)
 		}),
 
+    it('applies the "empty" class to the search input when no value is selected', () => {
+      const vm = new Vue({
+        template: '<div><v-select :options="options" multiple v-model="value"></v-select></div>',
+        components: {vSelect},
+        data: {
+          value: null,
+          options: [{label: 'one'}]
+        }
+      }).$mount()
+
+      expect(vm.$children[0].inputClasses.empty).toEqual(true)
+      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
+      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
+    }),
+
+    it('applies the "shrunk" class to the search input when one or more value is selected', () => {
+      const vm = new Vue({
+        template: '<div><v-select :options="options" multiple v-model="value"></v-select></div>',
+        components: {vSelect},
+        data: {
+          value: [{label: 'one'}],
+          options: [{label: 'one'}]
+        }
+      }).$mount()
+
+      expect(vm.$children[0].inputClasses.shrunk).toEqual(true)
+      expect(vm.$children[0].inputClasses.empty).toEqual(false)
+      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
+    }),
+
 		describe('change Event', () => {
 			it('will trigger the input event when the selection changes', (done) => {
 				const vm = new Vue({
@@ -1318,7 +1348,34 @@ describe('Select.vue', () => {
 				expect(vm.$refs.select.search).toEqual('')
 				done()
 			})
-		})
+    })
+
+    it('should apply the "empty" class to the search input when it does not have a selected value', () => {
+      const vm = new Vue({
+        template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
+        data: {
+          value: '',
+          options: ['one', 'two', 'three']
+        }
+      }).$mount()
+      expect(vm.$children[0].inputClasses.empty).toEqual(true)
+      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
+      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
+    })
+
+    it('should apply the "hidden" class to the search input when a value is present', () => {
+      const vm = new Vue({
+        template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
+        data: {
+          value: 'one',
+          options: ['one', 'two', 'three']
+        }
+      }).$mount()
+
+      expect(vm.$children[0].inputClasses.hidden).toEqual(true)
+      expect(vm.$children[0].inputClasses.empty).toEqual(false)
+      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
+    })
 
 		it ('should not reset the search input on focus lost when clearSearchOnSelect is false', (done) => {
 			const vm = new Vue({


### PR DESCRIPTION
Fixes https://github.com/sagalbot/vue-select/issues/460

What
---
- Hiding the search input field if the component is in the single value
option.
- Making the search input field full width if no options are selected in
	either single or multi select mode.
- Shrinking it to width auto if there are selected entries in multi
	mode.

Why
---

Before:
![image](https://user-images.githubusercontent.com/5814512/38931077-f1fa4ee8-4309-11e8-9856-ce977a708bb7.png)

After:
![image](https://user-images.githubusercontent.com/5814512/38931094-fd802de6-4309-11e8-876c-b03a828c3cc0.png)

Reason for being broken:
![image](https://user-images.githubusercontent.com/5814512/38931113-0ddfe5aa-430a-11e8-9d37-c1c329759d52.png)

The component broke into two lines when selecting a a value in single
mode, because an empty, non-interactable input field was pushed down to
the next row if the selected entry had a long label.

PS not sure if I did something weird with the indentation in the spec file?