### PR TITLE
bugfix: make placeholder visible for unsearchable input; make dropdown working on 'selected tag' click

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -208,7 +208,7 @@
     box-shadow: none;
   }
   .v-select.unsearchable input[type="search"] {
-    opacity: 0;
+    opacity: 1;
   }
   .v-select.unsearchable input[type="search"]:hover {
     cursor: pointer;

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -835,7 +835,7 @@
        * @return {void}
        */
       toggleDropdown(e) {
-        if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle || e.target === this.$el) {
+        // if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle || e.target === this.$el) {
           if (this.open) {
             this.$refs.search.blur() // dropdown will close on blur
           } else {
@@ -844,7 +844,7 @@
               this.$refs.search.focus()
             }
           }
-        }
+        // }
       },
 
       /**


### PR DESCRIPTION
I can't understand why  input  opacity is set to 0 for unsearchable input. Its not showing placeholder then. 