### PR TITLE
feat(clear) added slot to override clear button

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -47,6 +47,12 @@
                 {{option.label}} ({{option.value}})
             </template>
         </v-select>
+
+        <v-select placeholder="custom close template" :options="options">
+            <template slot="clear">
+                <span>=D</span>
+            </template>
+        </v-select>
         <v-select placeholder="custom option template for string array" taggable :options="['cat', 'dog', 'bear']" multiple>
             <template slot="selected-option" slot-scope="option">
                 {{option.label}}

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -90,13 +90,17 @@
     position: absolute;
     bottom: 9px;
     right: 30px;
+    background-color: transparent;
+    padding: 0;
+    border: 0;
+  }
+  .v-select .dropdown-toggle .clear .cross{
     font-size: 23px;
     font-weight: 700;
     line-height: 1;
     color: rgba(60, 60, 60, .5);
     padding: 0;
     border: 0;
-    background-color: transparent;
     cursor: pointer;
   }
 
@@ -345,16 +349,17 @@
               :id="inputId"
               aria-label="Search for option"
       >
-
-      <button 
-        v-show="showClearButton" 
-        :disabled="disabled" 
+      <button
+        v-show="showClearButton"
+        :disabled="disabled"
         @click="clearSelection"
-        type="button" 
-        class="clear" 
-        title="Clear selection" 
+        type="button"
+        class="clear"
+        title="Clear selection"
       >
-        <span aria-hidden="true">&times;</span>
+        <slot name="clear">
+          <span class="cross" aria-hidden="true">&times;</span>
+        </slot>
       </button>
 
       <i v-if="!noDrop" ref="openIndicator" role="presentation" class="open-indicator"></i>


### PR DESCRIPTION
Added a "clear" slot to override the "x" button with something else (fontawesome icons for instance)

Added an example in the dev file. 