### PR TITLE
Inherit font-family instead of using 'sans-serif'

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1,7 +1,7 @@
 <style>
   .v-select {
     position: relative;
-    font-family: sans-serif;
+    font-family: inherit;
   }
 
   .v-select,


### PR DESCRIPTION
This PR just makes the component inherit font-family from the application instead of overriding it with 'sans-serif'