### PR TITLE
Use a Flexbox-based Layout

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -224,17 +224,12 @@
     cursor: pointer;
   }
   .v-select input[type="search"].hidden {
-    width: 0px;
+    height: 0;
     padding: 0;
-  }
-  .v-select input[type="search"].shrunk {
-    width: auto;
-  }
-  .v-select input[type="search"].empty {
-    width: 100%;
+    width: 0;
   }
 
-    /* List Items */
+  /* List Items */
   .v-select li {
     line-height: 1.42857143; /* Normalize line height */
   }
@@ -1002,9 +997,7 @@
        */
       inputClasses() {
         return {
-          hidden: !this.multiple && !this.isValueEmpty && !this.dropdownOpen,
-          shrunk: this.multiple && !this.isValueEmpty,
-          empty: this.isValueEmpty,
+          hidden: !this.isValueEmpty && !this.dropdownOpen
         }
       },
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -67,7 +67,7 @@
     -moz-appearance: none;
     appearance: none;
     display: flex;
-    padding: 0;
+    padding: 0 0 4px 0;
     background: none;
     border: 1px solid rgba(60, 60, 60, .26);
     border-radius: 4px;
@@ -86,7 +86,7 @@
     flex-basis: 100%;
     flex-grow: 1;
     flex-wrap: wrap;
-    padding: 0 2px 4px;
+    padding: 0 2px;
   }
   .v-select .v-select__actions {
     display: flex;
@@ -146,10 +146,11 @@
   .v-select .selected-tag {
     display: flex;
     align-items: center;
-    color: #333;
     background-color: #f0f0f0;
     border: 1px solid #ccc;
     border-radius: 4px;
+    color: #333;
+    line-height: 1.42857143; /* Normalize line height */
     margin: 4px 2px 0px 2px;
     padding: 0 0.25em;
   }
@@ -196,12 +197,11 @@
     -moz-appearance: none;
     line-height: 1.42857143;
     font-size: 1em;
-    height: auto;
     display: inline-block;
-    border: none;
+    border: 1px solid transparent;
     outline: none;
-    margin: 0;
-    padding: 0 .5em;
+    margin: 4px 0 0 0;
+    padding: 0 0.5em;
     max-width: 100%;
     background: none;
     box-shadow: none;
@@ -223,6 +223,7 @@
     cursor: pointer;
   }
   .v-select input[type="search"].hidden {
+    border: none;
     height: 0;
     padding: 0;
     width: 0;

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -204,7 +204,6 @@
     padding: 0 .5em;
     max-width: 100%;
     background: none;
-    position: relative;
     box-shadow: none;
 
     /* `flex-grow` will stretch the input to take all remaining space, but We

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -30,13 +30,13 @@
 
   /* Open Indicator */
   .v-select .open-indicator {
-    display: inline-block;
+    display: flex;
+    align-items: center;
     cursor: pointer;
     pointer-events: all;
     transition: all 150ms cubic-bezier(1.000, -0.115, 0.975, 0.855);
     transition-timing-function: cubic-bezier(1.000, -0.115, 0.975, 0.855);
     opacity: 1;
-    height: 16px;
     width: 12px; /* To account for extra width from rotating. */
   }
   .v-select .open-indicator:before {
@@ -59,9 +59,6 @@
   }
   .v-select.loading .open-indicator {
     opacity: 0;
-  }
-  .v-select.open .open-indicator {
-    bottom: 1px;
   }
 
   /* Dropdown Toggle */
@@ -93,7 +90,7 @@
   }
   .v-select .v-select__actions {
     display: flex;
-    align-items: center;
+    align-items: stretch;
     padding: 0 4px 0 3px;
   }
 
@@ -268,6 +265,7 @@
   }
   /* Loading Spinner */
   .v-select .spinner {
+    align-self: center;
     opacity: 0;
     font-size: 5px;
     text-indent: -9999em;

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -14,15 +14,11 @@
      attribute does most of the work for us by rearranging the child elements visually.
    */
   .v-select[dir="rtl"] .v-select__actions {
-    padding: 0 3px 0 6px;
+    padding: 0 3px 0 4px;
   }
   .v-select[dir="rtl"] .dropdown-toggle .clear {
     margin-left: 6px;
     margin-right: 0;
-  }
-  .v-select[dir="rtl"] .selected-tag {
-    margin-right: 3px;
-    margin-left: 1px;
   }
   .v-select[dir="rtl"] .selected-tag .close {
     margin-left: 0;
@@ -93,11 +89,12 @@
     flex-basis: 100%;
     flex-grow: 1;
     flex-wrap: wrap;
+    padding: 0 2px 4px;
   }
   .v-select .v-select__actions {
     display: flex;
     align-items: center;
-    padding: 0 6px 0 3px;
+    padding: 0 4px 0 3px;
   }
 
   /* Clear Button */
@@ -151,15 +148,13 @@
   /* Selected Tags */
   .v-select .selected-tag {
     display: flex;
-    align-items: baseline;
+    align-items: center;
     color: #333;
     background-color: #f0f0f0;
     border: 1px solid #ccc;
     border-radius: 4px;
-    height: 26px;
-    margin: 4px 1px 0px 3px;
-    padding: 1px 0.25em;
-    line-height: 24px;
+    margin: 4px 2px 0px 2px;
+    padding: 0 0.25em;
   }
   .v-select.single .selected-tag {
     background-color: transparent;
@@ -204,7 +199,7 @@
     -moz-appearance: none;
     line-height: 1.42857143;
     font-size:1em;
-    height: 34px;
+    height: auto;
     display: inline-block;
     border: none;
     outline: none;

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -329,7 +329,7 @@
   <div :dir="dir" class="dropdown v-select" :class="dropdownClasses">
     <div ref="toggle" @mousedown.prevent="toggleDropdown" class="dropdown-toggle clearfix">
 
-      <div class="v-select__selected-options">
+      <div class="v-select__selected-options" ref="selectedOptions">
         <slot v-for="option in valueAsArray" name="selected-option-container"
               :option="(typeof option === 'object')?option:{[label]: option}" :deselect="deselect" :multiple="multiple" :disabled="disabled">
           <span class="selected-tag" v-bind:key="option.index">
@@ -856,7 +856,8 @@
        * @return {void}
        */
       toggleDropdown(e) {
-        if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle || e.target === this.$el) {
+        if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle ||
+            e.target === this.$refs.selectedOptions || e.target === this.$el) {
           if (this.open) {
             this.$refs.search.blur() // dropdown will close on blur
           } else {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -99,7 +99,7 @@
     font-size: 23px;
     font-weight: 700;
     line-height: 1;
-    color: rgba(60, 60, 60, .5);
+    color: rgba(60, 60, 60, 0.5);
     padding: 0;
     border: 0;
     background-color: transparent;
@@ -163,7 +163,7 @@
   }
   .v-select .selected-tag .close {
     margin-left: 2px;
-    font-size: 20px;
+    font-size: 1.25em;
     appearance: none;
     padding: 0;
     cursor: pointer;
@@ -195,7 +195,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     line-height: 1.42857143;
-    font-size:1em;
+    font-size: 1em;
     height: auto;
     display: inline-block;
     border: none;

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -210,11 +210,20 @@
     outline: none;
     margin: 0;
     padding: 0 .5em;
-    width: 10em;
     max-width: 100%;
     background: none;
     position: relative;
     box-shadow: none;
+
+    /* `flex-grow` will stretch the input to take all remaining space, but We
+       need to ensure a small amount of space so there's room to type input. We'll
+       set the input to "hidden" (via width: 0) when the dropdown is closed, to
+       prevent adding a "blank" line (see: https://github.com/sagalbot/vue-select/pull/512).
+       In that case, the flex-grow will still stretch the input to take any
+       available space, on the same "line."
+    */
+    flex-grow: 1;
+    width: 4em;
   }
   .v-select.unsearchable input[type="search"] {
     opacity: 0;

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -249,36 +249,6 @@ describe('Select.vue', () => {
 			expect(vm.$children[0].isOptionSelected('foo')).toEqual(true)
 		}),
 
-    it('applies the "empty" class to the search input when no value is selected', () => {
-      const vm = new Vue({
-        template: '<div><v-select :options="options" multiple v-model="value"></v-select></div>',
-        components: {vSelect},
-        data: {
-          value: null,
-          options: [{label: 'one'}]
-        }
-      }).$mount()
-
-      expect(vm.$children[0].inputClasses.empty).toEqual(true)
-      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
-      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
-    }),
-
-    it('applies the "shrunk" class to the search input when one or more value is selected', () => {
-      const vm = new Vue({
-        template: '<div><v-select :options="options" multiple v-model="value"></v-select></div>',
-        components: {vSelect},
-        data: {
-          value: [{label: 'one'}],
-          options: [{label: 'one'}]
-        }
-      }).$mount()
-
-      expect(vm.$children[0].inputClasses.shrunk).toEqual(true)
-      expect(vm.$children[0].inputClasses.empty).toEqual(false)
-      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
-    }),
-
 		describe('change Event', () => {
 			it('will trigger the input event when the selection changes', (done) => {
 				const vm = new Vue({
@@ -1350,19 +1320,6 @@ describe('Select.vue', () => {
 			})
     })
 
-    it('should apply the "empty" class to the search input when it does not have a selected value', () => {
-      const vm = new Vue({
-        template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
-        data: {
-          value: '',
-          options: ['one', 'two', 'three']
-        }
-      }).$mount()
-      expect(vm.$children[0].inputClasses.empty).toEqual(true)
-      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
-      expect(vm.$children[0].inputClasses.hidden).toEqual(false)
-    })
-
     it('should apply the "hidden" class to the search input when a value is present', () => {
       const vm = new Vue({
         template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
@@ -1373,10 +1330,7 @@ describe('Select.vue', () => {
       }).$mount()
 
       expect(vm.$children[0].inputClasses.hidden).toEqual(true)
-      expect(vm.$children[0].inputClasses.empty).toEqual(false)
-      expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
     })
-
 
     it('should not apply the "hidden" class to the search input when a value is present, and the dropdown is open', () => {
       const vm = new Vue({
@@ -1392,8 +1346,6 @@ describe('Select.vue', () => {
         Vue.nextTick(() => {
           expect(vm.$children[0].open).toEqual(true)
           expect(vm.$children[0].inputClasses.hidden).toEqual(false)
-          expect(vm.$children[0].inputClasses.empty).toEqual(false)
-          expect(vm.$children[0].inputClasses.shrunk).toEqual(false)
           done()
         })
       })


### PR DESCRIPTION
This change moves away from floats and absolute positioning in favor of flexbox. Flexbox allows us to solve some of the more quirky issues we're having with elements (e.g, the input) being too big, causing "extra line breaks", vertical alignment of close buttons, etc... and simplified RTL support!

I did need to introduce two new child elements to the `dropdown-toggle` element. These are used to group all of the selected tags and the input in one group. And the "actions" (clear button, dropdown indicator, and spinner) in another. Doing so has the added benefit of no longer allowing selected tags from running "under" those “action” elements.

**NOTE:** The large blocks of change are due to white space differences from indenting inside those new wrapper elements. [View the diff ignoring white space](https://github.com/sagalbot/vue-select/pull/594/files?w=1) to see a more accurate representation of the change here.

This change should apply fairly cleanly atop #512. But I'm happy to rebase this atop that one once it's merged.

**BEFORE**

![vue_select_dev](https://user-images.githubusercontent.com/48658/42857780-658d3ed2-8a19-11e8-8513-b96470bfa087.jpg)

**AFTER**

![vue_select_dev](https://user-images.githubusercontent.com/48658/42857963-3c231fc0-8a1a-11e8-9bbe-4af2a443cdbb.jpg)