### PR TITLE
Clicking a Selected Tag Toggles the Dropdown

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -847,7 +847,8 @@
        * @return {void}
        */
       toggleDropdown(e) {
-        if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle || e.target === this.$el) {
+        if (e.target === this.$refs.openIndicator || e.target === this.$refs.search || e.target === this.$refs.toggle ||
+            e.target.classList.contains('selected-tag') || e.target === this.$el) {
           if (this.open) {
             this.$refs.search.blur() // dropdown will close on blur
           } else {

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -433,6 +433,26 @@ describe('Select.vue', () => {
 			})
 		})
 
+		it('should open the dropdown when the selected tag is clicked', (done) => {
+			const vm = new Vue({
+				template: '<div><v-select :options="options" :value="value"></v-select></div>',
+				components: {vSelect},
+				data: {
+					value: [{label: 'one'}],
+					options: [{label: 'one'}]
+				}
+			}).$mount()
+
+			const selectedTag = vm.$children[0].$el.getElementsByClassName('selected-tag')[0]
+			vm.$children[0].toggleDropdown({target: selectedTag})
+			Vue.nextTick(() => {
+				Vue.nextTick(() => {
+					expect(vm.$children[0].open).toEqual(true)
+					done()
+				})
+			})
+		})
+
 		it('can close the dropdown when the el is clicked', (done) => {
 			const vm = new Vue({
 				template: '<div><v-select></v-select></div>',


### PR DESCRIPTION
I'm not sure how you feel about looking specifically for the `selected-tag` class when filtering the `toggleDropdown` event handler, but targeting it specifically seemed in line with the other handlers. But because the tags are repeated, and not directly part of a `v-for`, we can't use `$refs` to access them. This seemed an OK compromise... 🤷‍♀️ 