### PR TITLE
Adding a search:cleared event to ajax mixin search() watch function when search length is 0

### DIFF
--- a/src/mixins/ajax.js
+++ b/src/mixins/ajax.js
@@ -37,12 +37,17 @@ module.exports = {
 		/**
 		 * If a callback & search text has been provided,
 		 * invoke the onSearch callback.
+		 * If search length is 0 return a search:cleared event
 		 */
 		search() {
+			console.log('search function')
 			if (this.search.length > 0) {
 				this.onSearch(this.search, this.toggleLoading)
         this.$emit('search', this.search, this.toggleLoading)
-      }
+      } else {
+		  console.log('cleared')
+		this.$emit('search:cleared')
+	  }
 		},
     /**
 		 * Sync the loading prop with the internal

--- a/src/mixins/ajax.js
+++ b/src/mixins/ajax.js
@@ -45,7 +45,6 @@ module.exports = {
 				this.onSearch(this.search, this.toggleLoading)
         this.$emit('search', this.search, this.toggleLoading)
       } else {
-		  console.log('cleared')
 		this.$emit('search:cleared')
 	  }
 		},


### PR DESCRIPTION
Fixing issue #571 , where you couldn't tell if the search was cleared. Added an else to the current check in ajax.js (search() watch function). This now emits a "search:cleared" event. 