### PR TITLE
Do not hide input while loading options.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1080,7 +1080,7 @@
        */
       inputClasses() {
         return {
-          hidden: !this.isValueEmpty && !this.dropdownOpen
+          hidden: !this.isValueEmpty && !this.dropdownOpen && !this.mutableLoading
         }
       },
 

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1603,7 +1603,6 @@ describe('Select.vue', () => {
       expect(vm.$children[0].inputClasses.hidden).toEqual(true)
     })
 
-
     it('should not apply the "hidden" class to the search input when a value is present, and the dropdown is open', (done) => {
       const vm = new Vue({
         template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
@@ -1617,6 +1616,24 @@ describe('Select.vue', () => {
       Vue.nextTick(() => {
         Vue.nextTick(() => {
           expect(vm.$children[0].open).toEqual(true)
+          expect(vm.$children[0].inputClasses.hidden).toEqual(false)
+          done()
+        })
+      })
+    })
+
+    it('should not apply the "hidden" class to the search input when a value is present, the dropdown is closed, and options are loading', (done) => {
+      const vm = new Vue({
+        template: '<div><v-select ref="select" :options="options" :value="value"></v-select></div>',
+        data: {
+          value: 'one',
+          options: ['one', 'two', 'three'],
+          open: true
+        }
+      }).$mount()
+      vm.$refs.select.toggleLoading(true)
+      Vue.nextTick(() => {
+        Vue.nextTick(() => {
           expect(vm.$children[0].inputClasses.hidden).toEqual(false)
           done()
         })


### PR DESCRIPTION
Adding the `.hidden` class to the input while loading would cause it to lose padding. This would cause the text to "jump" back and forth.

### Before
![v-select-before](https://user-images.githubusercontent.com/48658/44544901-91df8f00-a6e1-11e8-88c1-16dcec165f61.gif)


### After
![v-select-after](https://user-images.githubusercontent.com/48658/44544910-93a95280-a6e1-11e8-9805-6657f7e447c8.gif)
