### PR TITLE
Added on-input to update search to fix mobile

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -341,7 +341,7 @@
                 @keydown.tab="onTab"
                 @blur="onSearchBlur"
                 @focus="onSearchFocus"
-                @input="searchQuery = $event.target.value"
+                @input="search = $event.target.value"
                 type="search"
                 class="form-control"
                 :class="inputClasses"

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -341,6 +341,7 @@
                 @keydown.tab="onTab"
                 @blur="onSearchBlur"
                 @focus="onSearchFocus"
+                @input="searchQuery = $event.target.value"
                 type="search"
                 class="form-control"
                 :class="inputClasses"


### PR DESCRIPTION
This fixes the typeahead results not updating on mobile. Related to https://github.com/vuejs/vue/issues/8231 which is a bug in VueJS.