### PR TITLE
TypeError handling when this.options isn't exist.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -795,9 +795,12 @@
      * attach any event listeners.
      */
     created() {
-      this.mutableValue = this.value
-      this.mutableOptions = this.options.slice(0)
-      this.mutableLoading = this.loading
+      this.mutableValue = this.value;
+      this.mutableOptions = '';
+      if (this.options){
+        this.mutableOptions = this.options.slice(0)
+      }
+      this.mutableLoading = this.loading;
 
       this.$on('option:created', this.maybePushTag)
     },

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -796,10 +796,12 @@
      */
     created() {
       this.mutableValue = this.value;
-      this.mutableOptions = '';
       if (this.options){
         this.mutableOptions = this.options.slice(0)
+      }else{
+          this.mutableOptions = '';
       }
+
       this.mutableLoading = this.loading;
 
       this.$on('option:created', this.maybePushTag)


### PR DESCRIPTION
when this.options isn't exist,
"TypeError: Cannot read property 'slice' of null" is occured,
so change the code, slicing it only when this.options is exist