### PR TITLE
Changed the filterFunction prop to filterBy

### DIFF
--- a/docs/gitbook/Api/Props.md
+++ b/docs/gitbook/Api/Props.md
@@ -137,14 +137,16 @@ getOptionLabel: {
 },
 
 /**
- * Callback to filter the search result the label text.
- * @type   {Function}
- * @param  {Object || String} option
- * @param  {String} label
- * @param  {String} search
- * @return {Boolean}
- */
-filterFunction: {
+* Callback to determine if the provided option should
+* match the current search text. Used to determine
+* if the option should be displayed.
+* @type   {Function}
+* @param  {Object || String} option
+* @param  {String} label
+* @param  {String} search
+* @return {Boolean}
+*/
+filterBy: {
 	type: Function,
 	default(option, label, search) {
 		return (label || '').toLowerCase().indexOf(search.toLowerCase()) > -1


### PR DESCRIPTION
The `filterFunction` prop does not exist in the source code. There is one called `filterBy` and I think it was just renamed at some point and you forgot to reflect it into the docs. That's just a blind guess tho, but I lost some time figuring out why the documented prop is not working, and that's why I decided to fix it. Hopefully others won't lost time on that, too :)