### PR TITLE
Added a prop for inputName on Select.vue.  Accepts String values.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -342,6 +342,7 @@
                 :tabindex="tabindex"
                 :readonly="!searchable"
                 :id="inputId"
+                :name="inputName"
                 role="combobox"
                 :aria-expanded="dropdownOpen"
                 aria-label="Search for option"
@@ -702,6 +703,15 @@
        */
       inputId: {
         type: String
+      },
+
+      /**
+       * Sets the name of the input element.
+       * @type {String}
+       * @default {null}
+       */
+      inputName: {
+          type: String
       },
 
       /**


### PR DESCRIPTION
Hi sagalbot,
I added a small change for this issue: https://github.com/sagalbot/vue-select/issues/591 because I think it would be useful to be able to have name attributes on the input fields.  Hope it works for you! Let me know if you'd like me to make any edits.