### PR TITLE
Support for optgroups

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -31,6 +31,7 @@
 <body>
     <div id="app">
         <v-select placeholder="default" :options="options"></v-select>
+        <v-select placeholder="optgroups" :options="optgroups"></v-select>
         <v-select placeholder="default, RTL" :options="options" dir="rtl"></v-select>
         <v-select placeholder="default, options=[1,5,10]" :options="[1,5,10]"></v-select>
         <v-select placeholder="multiple" multiple :options="options"></v-select>

--- a/dev/dev.js
+++ b/dev/dev.js
@@ -16,6 +16,20 @@ new Vue({
     placeholder: "placeholder",
     value: null,
     options: countries,
+    optgroups: [
+      'Text Not in Group', 
+      {
+        label: 'Text in group',
+        value: 'text-in-group'
+      },
+      {
+        title: 'Opt Group With Text Elements',
+        options: ['Item A', 'Item B', 'Item C']
+      },
+      {
+      title: 'Opt Group with Objects',
+      options: countries
+    }],
     ajaxRes: [],
     people: [],
     fuseSearchOptions

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -132,6 +132,11 @@
     list-style: none;
     background: #fff;
   }
+  .v-select .dropdown-menu .optgroup-header {
+    display: block;
+    padding: 5px;
+    background: rgba(50, 50, 50, .1);
+  }
   .v-select .no-options {
     text-align: center;
   }
@@ -371,8 +376,9 @@
     <transition :name="transition">
       <ul ref="dropdownMenu" v-if="dropdownOpen" class="dropdown-menu" :style="{ 'max-height': maxHeight }" role="listbox" @mousedown="onMousedown">
         <li role="option" v-for="(option, index) in filteredOptions" v-bind:key="index" :class="{ active: isOptionSelected(option), highlight: index === typeAheadPointer }" @mouseover="typeAheadPointer = index">
-          <a @mousedown.prevent.stop="select(option)">
-          <slot name="option" v-bind="(typeof option === 'object')?option:{[label]: option}">
+          <span class="optgroup-header" v-if="option.optgroup">{{option.optgroup}}</span>
+          <a v-if="!option.optgroup" @mousedown.prevent.stop="select(option)">
+          <slot v-if="!option.optgroup" name="option" v-bind="(typeof option === 'object')?option:{[label]: option}">
             {{ getOptionLabel(option) }}
           </slot>
           </a>
@@ -659,6 +665,7 @@
             }
             return this.filterBy(option, label, search)
           });
+        
         }
       },
 
@@ -765,7 +772,7 @@
        * @return {void}
        */
       options(val) {
-        this.mutableOptions = val
+        this.mutableOptions = this.normaliseOptGroups(val)
       },
 
       /**
@@ -796,14 +803,27 @@
      */
     created() {
       this.mutableValue = this.value
-      this.mutableOptions = this.options.slice(0)
+      this.mutableOptions = this.normaliseOptGroups(this.options.slice(0))
       this.mutableLoading = this.loading
 
       this.$on('option:created', this.maybePushTag)
     },
 
     methods: {
-
+      /** check if the list has elements which have 
+       *  title and a list of options, and flatten out 
+       */
+      normaliseOptGroups(val) {
+        return val.map(item => {
+          if (item.title && item.options && item.options instanceof Array) {
+            return [{optgroup : item.title}].concat(item.options)
+          } else {
+            return [item]
+          }
+        }).reduce((arr, group) => {
+          return arr.concat(group)
+        },[])
+      },
       /**
        * Select a given option.
        * @param  {Object|String} option


### PR DESCRIPTION
I've added support for optgroups 
Optgroups can be passed as part of the options with the following structure
```
{
   title: "lorem ipsum" // This is the title of the opt group
   option: []  // the options in that opt group, either as strings or as objects
}
These can be mixed with items not in any opt groups.

What i did is that before setting the mutableOptions, the optgroups are flattened out using the function ```normaliseOptGroups``` . 
In the template there is a check to see if the item is an optgroup to just render a non clickable list item.
