### PR TITLE
Proposed fix for #648

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -377,7 +377,7 @@
           </slot>
           </a>
         </li>
-        <li v-if="!filteredOptions.length" class="no-options">
+        <li v-if="!filteredOptions.length" class="no-options" @mousedown.stop="">
           <slot name="no-options">Sorry, no matching options.</slot>
         </li>
       </ul>


### PR DESCRIPTION
The components can't focus and the dropdown can't close when clicking 'Sorry, no matching options' 
https://github.com/sagalbot/vue-select/issues/648

I think if we just stop the propagation of the click event, this should resolve the issue. Otherwise it bubbles up to the UL.