### PR TITLE
Disable individual options

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -71,6 +71,7 @@
         <v-select placeholder="select on tab" :select-on-tab="true" :options="options"></v-select>
         <v-select placeholder="disabled" disabled  value="disabled"></v-select>
         <v-select placeholder="disabled multiple" disabled multiple :value="['disabled', 'multiple']"></v-select>
+        <v-select placeholder="disabled option" :options="[{ label:'Foo', value:'foo' }, { label:'Bar', value:'bar', disabled: true }, { label:'Baz', value:'baz' }]"></v-select>
         <v-select placeholder="filterable=false, @search=searchPeople" label="first_name" :filterable="false" @search="searchPeople" :options="people"></v-select>
         <v-select placeholder="filtering with fuse.js" label="title" :options="fuseSearchOptions" :filter="fuseSearch">
             <template slot="option" scope="option">

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -820,8 +820,7 @@
        * @return {void}
        */
       select(option) {
-        const origOption = this.mutableOptions.filter((o) => o === option || o.value === option)[0]
-        if(option.disabled || origOption.disabled) {
+        if(option && option.disabled) {
           return false
         }
         if (!this.isOptionSelected(option)) {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -820,7 +820,8 @@
        * @return {void}
        */
       select(option) {
-        if(option.disabled) {
+        const origOption = this.mutableOptions.filter((o) => o === option || o.value === option)[0]
+        if(option.disabled || origOption.disabled) {
           return false
         }
         if (!this.isOptionSelected(option)) {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -227,6 +227,16 @@
   .v-select li:hover {
     cursor: pointer;
   }
+  .v-select li[disabled] {
+    cursor: not-allowed;
+  }
+  .v-select li[disabled] a {
+    color: #aaa;
+    pointer-events: none;
+  }
+  .v-select li[disabled].highlight a {
+    background: #aaa;
+  }
   .v-select .dropdown-menu .active > a {
     color: #333;
     background: rgba(50, 50, 50, .1);
@@ -370,7 +380,7 @@
 
     <transition :name="transition">
       <ul ref="dropdownMenu" v-if="dropdownOpen" class="dropdown-menu" :style="{ 'max-height': maxHeight }" role="listbox" @mousedown="onMousedown">
-        <li role="option" v-for="(option, index) in filteredOptions" v-bind:key="index" :class="{ active: isOptionSelected(option), highlight: index === typeAheadPointer }" @mouseover="typeAheadPointer = index">
+        <li role="option" v-for="(option, index) in filteredOptions" v-bind:key="index" :class="{ active: isOptionSelected(option), highlight: index === typeAheadPointer }" @mouseover="typeAheadPointer = index" :disabled="option.disabled">
           <a @mousedown.prevent.stop="select(option)">
           <slot name="option" v-bind="(typeof option === 'object')?option:{[label]: option}">
             {{ getOptionLabel(option) }}
@@ -810,6 +820,9 @@
        * @return {void}
        */
       select(option) {
+        if(option.disabled) {
+          return false
+        }
         if (!this.isOptionSelected(option)) {
           if (this.taggable && !this.optionExists(option)) {
             option = this.createOption(option)

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -265,6 +265,16 @@ describe('Select.vue', () => {
 			expect(vm.$children[0].isOptionSelected('foo')).toEqual(true)
 		}),
 
+		it('should not be able to select disabled elements', () => {
+			const vm = new Vue({
+				template: `<div><v-select ref="select" :options="[{label: 'foo', value: 'foo', disabled: true}, {label: 'bar', value: 'bar'}]"></v-select></div>`,
+			}).$mount()
+
+			vm.$refs.select.select('foo')
+
+			expect(vm.$children[0].isOptionSelected('foo')).toEqual(false)
+		}),
+
 		describe('change Event', () => {
 			it('will trigger the input event when the selection changes', (done) => {
 				const vm = new Vue({

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -270,7 +270,7 @@ describe('Select.vue', () => {
 				template: `<div><v-select ref="select" :options="[{label: 'foo', value: 'foo', disabled: true}, {label: 'bar', value: 'bar'}]"></v-select></div>`,
 			}).$mount()
 
-			vm.$refs.select.select('foo')
+			vm.$refs.select.select({label: 'foo', value: 'foo', disabled: true})
 
 			expect(vm.$children[0].isOptionSelected('foo')).toEqual(false)
 		}),


### PR DESCRIPTION
Added a possibility to disable individual options rather than the whole Select element. 

Usage: 
```js
<v-select
  ref="select"
  :options="[{label: 'foo', value: 'foo', disabled: true},{label: 'bar', value: 'bar'}]"
></v-select>
```
in this example the option `foo` will be disabled
