### PR TITLE
Issue #241 - Allow setting maxlength on search input field

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -342,6 +342,7 @@
                 :tabindex="tabindex"
                 :readonly="!searchable"
                 :id="inputId"
+                :maxlength="maxlength"
                 role="combobox"
                 :aria-expanded="dropdownOpen"
                 aria-label="Search for option"
@@ -589,6 +590,18 @@
       taggable: {
         type: Boolean,
         default: false
+      },
+
+
+      /**
+       * Sets the maximum length of the search input,
+       * which affects the maximum length tag that can
+       * be created when tagging is enabled.
+       * @type {Number}
+       */
+      maxlength: {
+        type: Number,
+        default: undefined
       },
 
       /**

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1179,6 +1179,19 @@ describe('Select.vue', () => {
 			})
 		})
 
+		it('can set the maxlength of the search input field', () => {
+			const vm = new Vue({
+				template: '<div><v-select :options="options" :value="value" :multiple="true" :maxlength="10" taggable></v-select></div>',
+				components: {vSelect},
+				data: {
+					value: ['one'],
+					options: ['one', 'two']
+				}
+			}).$mount()
+
+			expect(vm.$children[0].$refs.search.maxLength).toEqual(10)
+		})
+
 		it('can select the current search text as an object', (done) => {
 			const vm = new Vue({
 				template: '<div><v-select :options="options" :value="value" :multiple="true" taggable></v-select></div>',


### PR DESCRIPTION
Allow sending maxlength as a prop to limit character in the search field. This also will limit the length of tags that can be added. This was an existing issue in GitHub, but also affects my team's production application.