### PR TITLE
Tagging UX improvement: Refocus on input after adding a tag in noDrop

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -877,6 +877,9 @@
         if (this.clearSearchOnSelect) {
           this.search = ''
         }
+        if (this.noDrop) {
+          this.focusInput()
+        }
       },
 
       /**
@@ -1033,6 +1036,14 @@
         if (this.pushTags) {
           this.mutableOptions.push(option)
         }
+      },
+
+      /**
+       * Gives focus to the input element.
+       * @return {void}
+       */
+      focusInput() {
+        this.$nextTick(() => this.$refs.search.focus())
       },
 
       /**


### PR DESCRIPTION
What
---
- If the `noDrop` prop is set to true, and the user is typing in tags,
always refocus the input after each added element.

Why
---
Because at the moment the user needs to click on the element after
adding each tag, this allows for a more fluid user experience.

### Before:
![vue select before](https://user-images.githubusercontent.com/5814512/48261071-afd1ab80-e415-11e8-8416-8ef88258e990.gif)

### After:
![vue select after](https://user-images.githubusercontent.com/5814512/48261082-ba8c4080-e415-11e8-8dee-7dd3d74eba36.gif)
