### PR TITLE
Solved problems with null object in options

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -542,7 +542,7 @@
             option = this.findOptionByIndexValue(option)
           }
 
-          if (typeof option === 'object') {
+          if (option && typeof option === 'object') {
             if (!option.hasOwnProperty(this.label)) {
               return console.warn(
                 `[vue-select warn]: Label key "option.${this.label}" does not` +


### PR DESCRIPTION
When was pushed a null object in **options** an error has occured:

> t is null; can't access its "hasOwnProperty" property

https://i.imgur.com/xBjvpV5.png

In line 545 in [Select.vue](https://github.com/sagalbot/vue-select/blob/master/src/components/Select.vue) is verified if the type of option is "object"

> if (typeof option === 'object') 

But if the option variable is **null** this validation is **true**, and in the next line the error occurs.

Addind a verification like this:

> if (option && typeof option === 'object')

The but will be fixed.