### PR TITLE
Only emit input on actual input events

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -566,7 +566,14 @@
       onChange: {
         type: Function,
         default: function (val) {
-          this.$emit('input', val)
+          this.$emit('change', val);
+        }
+      },
+
+      onInput: {
+        type: Function,
+        default: function (val) {
+          this.$emit('input', val);
         }
       },
 
@@ -830,6 +837,7 @@
           } else {
             this.mutableValue = option
           }
+          this.onInput(this.mutableValue);
         }
 
         this.onAfterSelect(option)
@@ -853,6 +861,7 @@
         } else {
           this.mutableValue = null
         }
+        this.onInput(this.mutableValue);
       },
 
       /**
@@ -861,6 +870,7 @@
        */
       clearSelection() {
         this.mutableValue = this.multiple ? [] : null
+        this.onInput(this.mutableValue)
       },
 
       /**


### PR DESCRIPTION
Separated the input event from the change event, which will still occur upon any change of value (programmatic, user, whathaveyou).

The input event now only occurs upon user input as is standard with all other components and form fields. 

This resolves #659
Resolves #573 
Resolves #545 
Resolves #526 
Resolves #504 
Resolves #455 
