### PR TITLE
Fix mark as selected for array of objects

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -907,7 +907,7 @@
           let selected = false
           this.valueAsArray.forEach(value => {
             if (typeof value === 'object') {
-              selected = this.optionObjectComparator(value, option)
+              selected = this.optionObjectComparator(value, option) || selected
             } else if (value === option || value === option[this.index]) {
               selected = true
             }


### PR DESCRIPTION
Disclaimer: there are other pull request to fix this, but mine is one-liner:)

Fixing the bug: for array of objects only one field gets marked as selected, because this.optionObjectComparator owerwrites the results of previous checks. This happens when more then 2 items are selected and we deal with array of objects. Then, when checking n's selected option, n-1 is always marked as not selected.

This simple fix corrects the situation.