### PR TITLE
Prop `texts` to customize vue-select texts (ie. internationalization)

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -33,6 +33,7 @@
         <v-select placeholder="default" :options="options"></v-select>
         <v-select placeholder="default, RTL" :options="options" dir="rtl"></v-select>
         <v-select placeholder="default, options=[1,5,10]" :options="[1,5,10]"></v-select>
+        <v-select placeholder="default, custom texts" :options="[1,5,10]" :texts="{'clearSelection':'remove', 'noResults':'Nothing found'}"></v-select>
         <v-select placeholder="multiple" multiple :options="options"></v-select>
         <v-select placeholder="multiple, taggable" multiple taggable :options="options" no-drop></v-select>
         <v-select placeholder="multiple, taggable, push-tags" multiple push-tags taggable :options="[{label: 'Foo', value: 'foo'}]"></v-select>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -344,7 +344,7 @@
                 :id="inputId"
                 role="combobox"
                 :aria-expanded="dropdownOpen"
-                aria-label="Search for option"
+                :aria-label="textValues.searchOption"
         >
 
       </div>
@@ -355,7 +355,7 @@
           @click="clearSelection"
           type="button"
           class="clear"
-          title="Clear selection"
+          :title="this.textValues.clearSelection"
         >
           <span aria-hidden="true">&times;</span>
         </button>
@@ -363,7 +363,7 @@
         <i v-if="!noDrop" ref="openIndicator" role="presentation" class="open-indicator"></i>
 
         <slot name="spinner">
-          <div class="spinner" v-show="mutableLoading">Loading...</div>
+          <div class="spinner" v-show="mutableLoading">{{ textValues.loading }}</div>
         </slot>
       </div>
     </div>
@@ -378,7 +378,7 @@
           </a>
         </li>
         <li v-if="!filteredOptions.length" class="no-options" @mousedown.stop="">
-          <slot name="no-options">Sorry, no matching options.</slot>
+          <slot name="no-options">{{ textValues.noResults }}</slot>
         </li>
       </ul>
     </transition>
@@ -389,9 +389,10 @@
   import pointerScroll from '../mixins/pointerScroll'
   import typeAheadPointer from '../mixins/typeAheadPointer'
   import ajax from '../mixins/ajax'
+  import text from '../mixins/text'
 
   export default {
-    mixins: [pointerScroll, typeAheadPointer, ajax],
+    mixins: [pointerScroll, typeAheadPointer, ajax, text],
 
     props: {
       /**

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,5 +1,6 @@
 import ajax from './ajax'
 import pointer from './typeAheadPointer'
 import pointerScroll from './pointerScroll'
+import text from './text'
 
-export default { ajax, pointer, pointerScroll }
+export default { text, ajax, pointer, pointerScroll }

--- a/src/mixins/text.js
+++ b/src/mixins/text.js
@@ -1,0 +1,48 @@
+module.exports = {
+    
+    props: {
+
+        /**
+         *  Override vue-select default texts. 
+         *  By default vue-select will use theses values  
+         *  
+         *  noResults : "Sorry no matching options."
+         *  loading : "Loading..."
+         *  searchOption : "Search for options"
+         *  clearSelection : "Clear selection"
+         *  
+         *  @type {Object}
+         */
+        texts : {
+            type: Object, 
+            default : () => ({}),
+        },
+        
+    },
+
+    computed: {
+
+        /**
+         *  Return a dictionnary of text value to 
+         *  use. Default texts are overriding by 
+         *  texts prop. 
+         * 
+         *  @returns {Object}
+         */
+        textValues(){
+
+            var defaultTexts = {
+                noResults : "Sorry, no matching options.", 
+                loading : "Loading...",
+                searchOption : "Search for options",
+                clearSelection : "Clear selection"
+            }
+
+            return {
+                ...defaultTexts,
+                ...this.texts
+            }
+        }
+    },
+
+}

--- a/test/unit/specs/Select.spec.js
+++ b/test/unit/specs/Select.spec.js
@@ -1668,5 +1668,88 @@ describe('Select.vue', () => {
 			expect(buttonEl.disabled).toEqual(true);
 		})
 
+	})
+
+	describe('Texts customization', () => {
+
+		it('should use default text values if no texts given', (done) => {
+			const vm = new Vue({
+				template: `<div><v-select ref="select" :options="['foo','bar','baz']"></v-select></div>`,
+			}).$mount()
+
+			const buttonClear = vm.$el.querySelector( 'button.clear' )
+			expect(buttonClear.getAttribute('title')).toEqual('Clear selection');
+
+			const spinner = vm.$el.querySelector( 'div.spinner' )
+			expect(spinner.textContent).toEqual('Loading...')
+
+			const input = vm.$el.querySelector( 'input.form-control' )
+			expect(input.getAttribute('aria-label')).toEqual('Search for options')
+
+			vm.$refs.select.search = 'xxx'
+			vm.$children[0].open = true
+			Vue.nextTick(() => {
+				const noOptions  = vm.$el.querySelector( 'li.no-options' )
+				expect(noOptions.textContent).toEqual('Sorry, no matching options.')
+				done()
+			})
+
+		})
+
+		it('should use text values if texts given', (done) => {
+			const vm = new Vue({
+				template: '<div><v-select ref="select" :options="options" :value="value"  :texts="texts"></v-select></div>',
+				data: {
+					options: ['foo','bar'],
+					value : 'foo',
+					texts: {
+						noResults : "Nothing Found", 
+						loading : "Loading",
+						searchOption : "Options",
+						clearSelection : "Remove"
+					}
+				}
+			}).$mount()
+
+			const buttonClear = vm.$el.querySelector( 'button.clear' )
+			expect(buttonClear.getAttribute('title')).toEqual('Remove');
+
+			const spinner = vm.$el.querySelector( 'div.spinner' )
+			expect(spinner.textContent).toEqual('Loading')
+
+			const input = vm.$el.querySelector( 'input.form-control' )
+			expect(input.getAttribute('aria-label')).toEqual('Options')
+
+			vm.$refs.select.search = 'xxx'
+			vm.$children[0].open = true
+			Vue.nextTick(() => {
+				const noOptions  = vm.$el.querySelector( 'li.no-options' )
+				expect(noOptions.textContent).toEqual('Nothing Found')
+				done()
+			})
+
+		})
+
+		it('should use default text values if keywords are missing in texts prop', () => {
+			const vm = new Vue({
+				template: '<div><v-select ref="select" :options="options" :value="value"  :texts="texts"></v-select></div>',
+				data: {
+					options: ['foo','bar'],
+					value : 'foo',
+					texts: {
+						clearSelection : "Remove"
+					}
+				}
+			}).$mount()
+
+			const buttonClear = vm.$el.querySelector( 'button.clear' )
+			expect(buttonClear.getAttribute('title')).toEqual('Remove');
+
+			const spinner = vm.$el.querySelector( 'div.spinner' )
+			expect(spinner.textContent).toEqual('Loading...')
+
+		})
+
 	});
+
 })


### PR DESCRIPTION
Hello, 

I use vue-select on a multilanguage application, and i had some difficulties to translate hardcoded texts. For example _"Clear selection"_ is a ```title```  on button or _"Search for options"_ an ```aria-label``` on input. 

I know that for the others texts slots can be used. However we use v-select many and many times, and it become repetitives to write slots for each v-select instance.

With the ```texts``` props, we can write this snippet and translate / customize text once and for all when importing.

```js 
import vSelect from 'vue-select'

vSelect.props.texts = {
    type : Object, 
    default : () => ({
         noResults     : i18n.t("vSelect_noResults"),
         loading       : i18n.t("vSelect_loading"),
         searchOption  : i18n.t("vSelect_searchOption"),
         clearSelection: i18n.t("vSelect_clearSelection"),
    })
}

Vue.component('vSelect', vSelect)
``` 
Best regards ! 
