### PR TITLE
Clarification of prop usage.

### DIFF
--- a/docs/gitbook/Api/Props.md
+++ b/docs/gitbook/Api/Props.md
@@ -64,6 +64,8 @@ multiple: {
 
 /**
  * Equivalent to the `placeholder` attribute on an `<input>`.
+ * Placeholder for the search field `<input>` element.
+ * For setting the default value, use prop `default`.
  * @type {String}
  */
 placeholder: {


### PR DESCRIPTION
This little note will help reduce confusion. Props, `placeholder` and `default`, needed specification as they are similar.