### PR TITLE
Adding note to `placeholder` prop

### DIFF
--- a/docs/gitbook/Api/Props.md
+++ b/docs/gitbook/Api/Props.md
@@ -64,6 +64,8 @@ multiple: {
 
 /**
  * Equivalent to the `placeholder` attribute on an `<input>`.
+ * Placeholder for the search field `<input>` element.
+ * For setting the default value, use prop `value`.
  * @type {String}
  */
 placeholder: {


### PR DESCRIPTION
Added note to reduce confusion between default `value` and `placeholder`