### PR TITLE
Fix #575 Do not show scroll area when list is not big enough

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -123,7 +123,7 @@
     padding: 5px 0;
     margin: 0;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     border: 1px solid rgba(0, 0, 0, .26);
     box-shadow: 0px 3px 6px 0px rgba(0,0,0,.15);
     border-top: none;


### PR DESCRIPTION
fix #575 
Show scroll area only when necessary.

### Before
<img width="424" alt="_2019-02-07_17_36_04" src="https://user-images.githubusercontent.com/17819225/52399578-0d9e8e00-2b00-11e9-8939-8d7bc581188a.png">

### After
<img width="416" alt="2019-02-07 17 35 43" src="https://user-images.githubusercontent.com/17819225/52399584-0f685180-2b00-11e9-85dc-478536e2993f.png">
