### PR TITLE
Fixed bug for mobile browsers

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -26,6 +26,9 @@
             margin: 1em;
         }
     </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
 </head>
 
 <body>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -325,7 +325,8 @@
 
         <input
                 ref="search"
-                v-model="search"
+                :value="search"
+                @input="e => search = e.target.value"
                 @keydown.delete="maybeDeleteValue"
                 @keyup.esc="onEscape"
                 @keydown.up.prevent="typeAheadUp"


### PR DESCRIPTION
When you use the regular input tag on mobile browsers after the first character is typed the component freeze. Fixed this little bug by replacing the v-model for the @input method.

Even in the Codepen app, it happens as well as you can see:

![whatsapp image 2019-02-20 at 13 27 37](https://user-images.githubusercontent.com/17418590/53116492-ce683800-3516-11e9-93c8-9e02da1222c6.jpeg)


