### PR TITLE
Only ignore searchBlur while mouse is down

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -369,7 +369,7 @@
     </div>
 
     <transition :name="transition">
-      <ul ref="dropdownMenu" v-if="dropdownOpen" class="dropdown-menu" :style="{ 'max-height': maxHeight }" role="listbox" @mousedown="onMousedown">
+      <ul ref="dropdownMenu" v-if="dropdownOpen" class="dropdown-menu" :style="{ 'max-height': maxHeight }" role="listbox" @mousedown="onMousedown" @mouseup="onMouseup">
         <li role="option" v-for="(option, index) in filteredOptions" v-bind:key="index" :class="{ active: isOptionSelected(option), highlight: index === typeAheadPointer }" @mouseover="typeAheadPointer = index">
           <a @mousedown.prevent.stop="select(option)">
           <slot name="option" v-bind="(typeof option === 'object')?option:{[label]: option}">
@@ -1076,6 +1076,10 @@
        */
       onMousedown() {
         this.mousedown = true
+      },
+
+      onMouseup() {
+        this.mousedown = false
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/sagalbot/vue-select/issues/777

This maintains the existing functionality in IE11 but in modern browsers allows the options to be dismissed by clicking outside