### PR TITLE
fix bootstrap 4 CSS collisions

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -73,6 +73,9 @@
     border-radius: 4px;
     white-space: normal;
   }
+  .v-select .dropdown-toggle::after {
+    display: none;
+  }
   .v-select .vs__selected-options {
     display: flex;
     flex-basis: 100%;
@@ -205,6 +208,7 @@
     box-shadow: none;
     flex-grow: 1;
     width: 0;
+    height: inherit;
   }
   .v-select.unsearchable input[type="search"] {
     opacity: 0;


### PR DESCRIPTION
Before:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/692538/54869414-0ef4e480-4d55-11e9-8c5c-13956358ced4.png">

After:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/692538/54869400-e967db00-4d54-11e9-82cc-e6b697cc407d.png">

---
Closes #662 