### PR TITLE
move static classes to dropdownClasses computed prop

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -311,7 +311,7 @@
 </style>
 
 <template>
-  <div :dir="dir" class="dropdown v-select" :class="dropdownClasses">
+  <div :dir="dir" :class="dropdownClasses">
     <div ref="toggle" @mousedown.prevent="toggleDropdown" class="dropdown-toggle">
 
       <div class="vs__selected-options" ref="selectedOptions">
@@ -1096,6 +1096,8 @@
        */
       dropdownClasses() {
         return {
+          'v-select': true,
+          dropdown: true,
           open: this.dropdownOpen,
           single: !this.multiple,
           searching: this.searching,


### PR DESCRIPTION
Generated markup remains unchanged. 

![image](https://user-images.githubusercontent.com/692538/55750505-45d72580-59f8-11e9-886f-31b5b139e446.png)

The `v-select` and `dropdown` classes get moved to a computed property, making them easier to overwrite. 

---

Closes #820 