### PR TITLE
Docs: Add search watcher to upgrade guide

### DIFF
--- a/docs/guide/upgrading.md
+++ b/docs/guide/upgrading.md
@@ -69,6 +69,13 @@ has always provided the same parameters and can be used in it's place.
 <v-select @search="doSomeAjax" />
 ```
 
+### `onSearch` with null search string
+
+The `onSearch` callback is now fired anytime the search string changes. In v2.x, the component
+would first check if the search string was empty, and only run the callback if it had at least one
+character. This was a design mistake, as it should be the consumers decision if a search should be
+run on an empty string. 
+
 ## Separated CSS
 
 CSS was removed from the JS bundle in favor of a separate CSS file to support SSR and easier


### PR DESCRIPTION
Adds a note about null search queries to upgrade guide.

---

Closes #729 #620 #571 #240