### PR TITLE
refactor toggleDropdown for IE11 support

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -548,17 +548,17 @@
        * @return {void}
        */
       toggleDropdown (e) {
+        const target = e.target;
         const toggleTargets = [
           this.$el,
           this.searchEl,
           this.$refs.toggle.$el,
           this.$refs.openIndicator.$el,
-          ...Array.from(this.$refs.openIndicator.$el.children),
+          // the line below is a bit gross, but required to support IE11 without adding polyfills
+          ...Array.prototype.slice.call(this.$refs.openIndicator.$el.childNodes)
         ];
-        
-        const target = e.target;
 
-        if (toggleTargets.includes(target) || target.classList.contains('vs__selected')) {
+        if (toggleTargets.indexOf(target) > -1 || target.classList.contains('vs__selected')) {
           if (this.open) {
             this.searchEl.blur(); // dropdown will close on blur
           } else {


### PR DESCRIPTION
Removes calls to `[].from` and `[].includes` that would otherwise require a polyfill. Fixes IE11 support.

---

Closes #836 