### PR TITLE
Select tag on blur

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -710,6 +710,9 @@
         if (this.mousedown && !this.searching) {
           this.mousedown = false
         } else {
+          if (this.taggable && this.search.length) {
+            this.select(this.search)
+          }
           if (this.clearSearchOnBlur) {
             this.search = ''
           }

--- a/tests/unit/Tagging.spec.js
+++ b/tests/unit/Tagging.spec.js
@@ -221,4 +221,15 @@ describe("When Tagging Is Enabled", () => {
     expect(Select.vm.selectedValue).toEqual([{ label: "one" }]);
     expect(Select.vm.search).toEqual("");
   });
+
+  it("should select the current search text on focus lost", () => {
+    const Select = selectWithProps({
+      taggable: true
+    });
+
+    Select.vm.open = true;
+    Select.vm.search = "a tag";
+    Select.vm.onSearchBlur();
+    expect(Select.vm.selectedValue).toEqual(["a tag"]);
+  });
 });


### PR DESCRIPTION
Hi, I would like to suggest to save tag on blur, it could be useful for users in some cases.

A new behaviour example:
https://monosnap.com/file/7sFZdxr1t9NnW8gDw24FoQeU3xvw0G

I guess we also can add `selectTagOnBlur` prop to manage this behaviour if necessary.
 Thanks @omohokcoj for the idea.