### PR TITLE
only render functional components in the client

### DIFF
--- a/docs/guide/components.md
+++ b/docs/guide/components.md
@@ -28,7 +28,9 @@ export default {
 };
 ```
 
-<ClearButtonOverride />
+<ClientOnly>
+  <ClearButtonOverride />
+</ClientOnly>
 
 The same approach applies for `multiple` selects:
 
@@ -53,7 +55,9 @@ export default {
 };
 ```
 
-<OpenIndicatorOverride />
+<ClientOnly>
+  <OpenIndicatorOverride />
+</ClientOnly>
 
 ## Setting Globally at Registration
 
@@ -78,6 +82,7 @@ vSelect.props.components.default = () => ({
 Vue.component(vSelect)
 ```
 
-<CustomComponentRegistration />
-
+<ClientOnly>
+  <CustomComponentRegistration />
+</ClientOnly>
 


### PR DESCRIPTION
https://vue-select.org/guide/components.html breaks when rendered via SSR. This could be related to https://github.com/vuejs/vue-loader/issues/1170.

```
DOMException: "Node cannot be inserted at the specified point in the hierarchy"
```

The error gets thrown on a text node with a length of one:

![image](https://user-images.githubusercontent.com/692538/56917459-62eb9b00-6a70-11e9-81f5-3e8f19dc166f.png)

There's something more significant happening here, but this is a quick fix.
