### PR TITLE
add required validation doc

### DIFF
--- a/docs/.vuepress/components/ValidationRequired.vue
+++ b/docs/.vuepress/components/ValidationRequired.vue
@@ -1,0 +1,51 @@
+<template>
+  <form @submit.stop="onSubmit">
+    <v-select :options="books" label="title" v-model="selected">
+      <template #search="{attributes, events}">
+        <input
+          :required="!selected"
+          class="vs__search"
+          v-bind="attributes"
+          v-on="events"
+        />
+      </template>
+    </v-select>
+
+    <input type="submit">
+  </form>
+</template>
+
+<script>
+import books from '../data/books'
+export default {
+  data: () => ({
+    books,
+    selected: null,
+  }),
+  methods: {
+    onSubmit() {
+      alert('Submitted!');
+    }
+  }
+};
+</script>
+
+<style scoped>
+  form {
+    display: flex;
+    align-items: stretch;
+  }
+
+  .v-select {
+    width: 75%;
+  }
+
+  input[type="submit"] {
+    margin-left: 1rem;
+    background: #44ae7d;
+    border: none;
+    border-radius: 3px;
+    color: #fff;
+    width: 20%;
+  }
+</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -117,6 +117,7 @@ module.exports = {
           title: 'Digging Deeper',
           collapsable: false,
           children: [
+            ['guide/validation', 'Validation'],
             ['guide/vuex', 'Vuex'],
             ['guide/ajax', 'AJAX'],
           ],

--- a/docs/guide/validation.md
+++ b/docs/guide/validation.md
@@ -1,0 +1,24 @@
+## Required
+
+If you need to ensure that a selection is made before a form is submitted, you can 
+use the `required` attribute in combination with the `search` scoped slot in order 
+to do so.
+
+However, the `search` input within the component does not actually store a value, so
+simply adding the `required` attribute won't work. Instead, we'll bind the attribute
+dynamically, so that it's only present if we don't have a selection.
+
+<ValidationRequired />
+
+```html
+<v-select :options="books" label="title" v-model="selected">
+  <template #search="{attributes, events}">
+    <input
+      class="vs__search"
+      :required="!selected"
+      v-bind="attributes"
+      v-on="events"
+    />
+  </template>
+</v-select>
+```


### PR DESCRIPTION
Adds an example of how to use HTML5 `required` attribute with the component. 

This could probably be abstracted into a prop for easier use.

---

Closes #477 