### PR TITLE
Add label to new taggable item in dropdown

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -64,6 +64,7 @@
           <slot name="option" v-bind="normalizeOptionForSlot(option)">
             {{ getOptionLabel(option) }}
           </slot>
+          <span v-if="taggable && !optionExists(option)" class="vs__new-option-label">{{ newOptionLabel }}</span>
         </li>
         <li v-if="!filteredOptions.length" class="vs__no-options" @mousedown.stop="">
           <slot name="no-options">Sorry, no matching options.</slot>
@@ -421,7 +422,17 @@
       searchInputQuerySelector: {
         type: String,
         default: '[type=search]'
-      }
+      },
+
+      /**
+       * Sets the text that displays next to a new item in the dropdown when taggable is true
+       * @type {String}
+       * @default 'New'
+       */
+      newOptionLabel: {
+          type: String,
+          default: 'New'
+      },
     },
 
     data() {

--- a/src/scss/modules/_dropdown-menu.scss
+++ b/src/scss/modules/_dropdown-menu.scss
@@ -35,3 +35,9 @@ $max-height: $vs-dropdown-max-height;
 .vs__no-options {
   text-align: center;
 }
+
+.vs__new-option-label {
+  opacity: .5;
+  position: absolute;
+  right: 1em;
+}


### PR DESCRIPTION
This adds a label beside new options in the drop-down list to help distinguish it from other options. Example:

![Screenshot from 2019-06-24 17-22-36](https://user-images.githubusercontent.com/10846855/59999235-d5f64400-96a4-11e9-8697-22218ce6bdc6.png)

The text can be changed by setting the prop `new-option-label` to any string. It can be disabled by setting the string to `""`.