### PR TITLE
Fix dropdown not opening on overriden selected-option slots (#790)

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -17,7 +17,14 @@
             <slot name="selected-option" v-bind="normalizeOptionForSlot(option)">
               {{ getOptionLabel(option) }}
             </slot>
-            <button v-if="multiple" :disabled="disabled" @click="deselect(option)" type="button" class="vs__deselect" aria-label="Deselect option">
+            <button v-if="multiple"
+              :disabled="disabled"
+              @click="deselect(option)"
+              type="button"
+              class="vs__deselect"
+              aria-label="Deselect option"
+              ref="deselectButtons"
+            >
               <component :is="childComponents.Deselect" />
             </button>
           </span>
@@ -572,7 +579,14 @@
           );
         }
 
-        if (toggleTargets.indexOf(target) > -1 || target.classList.contains('vs__selected')) {
+        let deselectClicked = false;
+        if(typeof this.$refs.deselectButtons !== 'undefined') {
+          deselectClicked = this.$refs.deselectButtons.some((btnRef) => {
+            return btnRef.contains(target);
+          });
+        }
+
+        if (toggleTargets.indexOf(target) > -1 || (!deselectClicked && this.$refs.selectedOptions.contains(target))) {
           if (this.open) {
             this.searchEl.blur(); // dropdown will close on blur
           } else {


### PR DESCRIPTION
Even though #869 is open it seems to be a larger change, and as far as I can tell it's not really fixed, the only commit is a cleanup of toggleDropdown. Since the issue is tagged "help-wanted" anyway, I'm opening this

This fix (for #790) is fairly simple, instead of checking for vs__selected we check whether the target is a child node of the selectedOptions ref. I then realized that with this, clicking the deselect button would open the dropdown, which felt a bit weird, so I added the bit of extra logic to exclude those.