### PR TITLE
Allow to disable options with selectable function

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -57,9 +57,9 @@
           v-for="(option, index) in filteredOptions"
           :key="index"
           class="vs__dropdown-option"
-          :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer }"
+          :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer, 'vs__dropdown-option--disabled': !selectable(option) }"
           @mouseover="typeAheadPointer = index"
-          @mousedown.prevent.stop="select(option)"
+          @mousedown.prevent.stop="selectable(option) ? select(option) : null"
         >
           <slot name="option" v-bind="normalizeOptionForSlot(option)">
             {{ getOptionLabel(option) }}
@@ -222,6 +222,19 @@
       reduce: {
         type: Function,
         default: option => option,
+      },
+
+      /**
+       * Decides wether an option is selectable or not. Not selectable options
+       * are displayed but disabled and cannot be selected.
+       *
+       * @type {Function}
+       * @param {Object|String} option
+       * @return {Boolean}
+       */
+      selectable: {
+        type: Function,
+        default: option => true,
       },
 
       /**

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -58,7 +58,7 @@
           :key="index"
           class="vs__dropdown-option"
           :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer, 'vs__dropdown-option--disabled': !selectable(option) }"
-          @mouseover="typeAheadPointer = index"
+          @mouseover="selectable(option) ? typeAheadPointer = index : null"
           @mousedown.prevent.stop="selectable(option) ? select(option) : null"
         >
           <slot name="option" v-bind="normalizeOptionForSlot(option)">

--- a/src/mixins/typeAheadPointer.js
+++ b/src/mixins/typeAheadPointer.js
@@ -7,35 +7,46 @@ export default {
 
   watch: {
     filteredOptions() {
-      this.typeAheadPointer = 0
+      for (let i = 0; i < this.filteredOptions.length; i++) {
+        if (this.selectable(this.filteredOptions[i])) {
+          this.typeAheadPointer = i;
+          break;
+        }
+      }
     }
   },
 
   methods: {
     /**
      * Move the typeAheadPointer visually up the list by
-     * subtracting the current index by one.
+     * setting it to the previous selectable option.
      * @return {void}
      */
     typeAheadUp() {
-      if (this.typeAheadPointer > 0) {
-        this.typeAheadPointer--
-        if( this.maybeAdjustScroll ) {
-          this.maybeAdjustScroll()
+      for (let i = this.typeAheadPointer - 1; i >= 0; i--) {
+        if (this.selectable(this.filteredOptions[i])) {
+          this.typeAheadPointer = i;
+          if( this.maybeAdjustScroll ) {
+            this.maybeAdjustScroll()
+          }
+          break;
         }
       }
     },
 
     /**
      * Move the typeAheadPointer visually down the list by
-     * adding the current index by one.
+     * setting it to the next selectable option.
      * @return {void}
      */
     typeAheadDown() {
-      if (this.typeAheadPointer < this.filteredOptions.length - 1) {
-        this.typeAheadPointer++
-        if( this.maybeAdjustScroll ) {
-          this.maybeAdjustScroll()
+      for (let i = this.typeAheadPointer + 1; i < this.filteredOptions.length; i++) {
+        if (this.selectable(this.filteredOptions[i])) {
+          this.typeAheadPointer = i;
+          if( this.maybeAdjustScroll ) {
+            this.maybeAdjustScroll()
+          }
+          break;
         }
       }
     },

--- a/src/scss/modules/_dropdown-option.scss
+++ b/src/scss/modules/_dropdown-option.scss
@@ -16,3 +16,12 @@
   background: $vs-state-active-bg;
   color: $vs-state-active-color;
 }
+
+.vs__dropdown-option--disabled {
+  background: inherit;
+  color: $vs-state-disabled-color;
+
+  &:hover {
+    cursor: inherit;
+  }
+}

--- a/tests/unit/Selectable.spec.js
+++ b/tests/unit/Selectable.spec.js
@@ -1,0 +1,27 @@
+import { selectWithProps } from "../helpers";
+
+describe("Selectable prop", () => {
+  it("should select selectable option if clicked", () => {
+    const Select = selectWithProps({
+      options: ["one", "two", "three"],
+      selectable: (option) => option == "one"
+    });
+
+    Select.vm.$data.open = true;
+
+    Select.find(".vs__dropdown-menu li:first-child").trigger("mousedown");
+    expect(Select.vm.selectedValue).toEqual(["one"]);
+  })
+
+  it("should not select not selectable option if clicked", () => {
+    const Select = selectWithProps({
+      options: ["one", "two", "three"],
+      selectable: (option) => option == "one"
+    });
+
+    Select.vm.$data.open = true;
+
+    Select.find(".vs__dropdown-menu li:last-child").trigger("mousedown");
+    expect(Select.vm.selectedValue).toEqual([]);
+  });
+})

--- a/tests/unit/Selectable.spec.js
+++ b/tests/unit/Selectable.spec.js
@@ -24,4 +24,30 @@ describe("Selectable prop", () => {
     Select.find(".vs__dropdown-menu li:last-child").trigger("mousedown");
     expect(Select.vm.selectedValue).toEqual([]);
   });
+
+  it("should skip non-selectable option on down arrow keyUp", () => {
+    const Select = selectWithProps({
+      options: ["one", "two", "three"],
+      selectable: (option) => option !== "two"
+    });
+
+    Select.vm.typeAheadPointer = 1;
+
+    Select.find({ ref: "search" }).trigger("keyup.down");
+
+    expect(Select.vm.typeAheadPointer).toEqual(2);
+  })
+
+  it("should skip non-selectable option on up arrow keyUp", () => {
+    const Select = selectWithProps({
+      options: ["one", "two", "three"],
+      selectable: (option) => option !== "two"
+    });
+
+    Select.vm.typeAheadPointer = 2;
+
+    Select.find({ ref: "search" }).trigger("keyup.up");
+
+    expect(Select.vm.typeAheadPointer).toEqual(0);
+  })
 })

--- a/tests/unit/TypeAhead.spec.js
+++ b/tests/unit/TypeAhead.spec.js
@@ -18,7 +18,7 @@ describe("Moving the Typeahead Pointer", () => {
     expect(Select.vm.typeAheadPointer).toEqual(0);
   });
 
-  it("should move the pointer visually up the list on up arrow keyDown", () => {
+  it("should move the pointer visually up the list on up arrow keyUp", () => {
     const Select = mountDefault();
 
     Select.vm.typeAheadPointer = 1;
@@ -28,7 +28,7 @@ describe("Moving the Typeahead Pointer", () => {
     expect(Select.vm.typeAheadPointer).toEqual(0);
   });
 
-  it("should move the pointer visually down the list on down arrow keyDown", () => {
+  it("should move the pointer visually down the list on down arrow keyUp", () => {
     const Select = mountDefault();
 
     Select.vm.typeAheadPointer = 1;
@@ -47,7 +47,7 @@ describe("Moving the Typeahead Pointer", () => {
   });
 
   describe("Automatic Scrolling", () => {
-    it("should check if the scroll position needs to be adjusted on up arrow keyDown", () => {
+    it("should check if the scroll position needs to be adjusted on up arrow keyUp", () => {
       const Select = mountDefault();
       const spy = jest.spyOn(Select.vm, "maybeAdjustScroll");
 
@@ -57,7 +57,7 @@ describe("Moving the Typeahead Pointer", () => {
       expect(spy).toHaveBeenCalled();
     });
 
-    it("should check if the scroll position needs to be adjusted on down arrow keyDown", () => {
+    it("should check if the scroll position needs to be adjusted on down arrow keyUp", () => {
       const Select = mountDefault();
       const spy = jest.spyOn(Select.vm, "maybeAdjustScroll");
 


### PR DESCRIPTION
Implemented as per https://github.com/sagalbot/vue-select/pull/309#issuecomment-476777951

ToDo:

- [x] Write spec
- [x] Have it tested by some people

---

To test this in your project, you can use [my custom branch](https://github.com/doits/vue-select/tree/fix_initial_label_on_ajax_options_built) which incoperates this PR and #914 and has built packages.

**Disclaimer**: Not for production use, only provided for testing purposes. Might be bugged and eat your data.

In your `package.json`:

```json
"dependencies": {
    "vue-select": "https://github.com/doits/vue-select.git#fix_initial_label_on_ajax_options_built"
}
```