### PR TITLE
Fix dropdown-toggle not being registered correctly as a mousedown target

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -561,7 +561,7 @@
         const toggleTargets = [
           this.$el,
           this.searchEl,
-          this.$refs.toggle.$el,
+          this.$refs.toggle,
         ];
 
         if (typeof this.$refs.openIndicator !== 'undefined') {


### PR DESCRIPTION
The dropdown-toggle element is a plain HTML element, not a component. Therefore the ref refers to its element directly.