### PR TITLE
Reduce null values

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -508,7 +508,7 @@
     created() {
       this.mutableLoading = this.loading;
 
-      if (this.value && this.isTrackingValues) {
+      if (this.value !== null && this.isTrackingValues) {
         this.setInternalValueFromOptions(this.value)
       }
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -508,7 +508,7 @@
     created() {
       this.mutableLoading = this.loading;
 
-      if (this.value !== null && this.isTrackingValues) {
+      if (typeof this.value !== "undefined" && this.isTrackingValues) {
         this.setInternalValueFromOptions(this.value)
       }
 

--- a/tests/unit/Reduce.spec.js
+++ b/tests/unit/Reduce.spec.js
@@ -166,6 +166,20 @@ describe("When reduce prop is defined", () => {
     expect(Select.vm.selectedValue).toEqual([option]);
   });
 
+  it('works with null values', () => {
+    const option = {value: null, label: 'No'};
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        reduce: option => option.value,
+        options: [option, {value: 1, label: 'Yes'}],
+        value: null,
+      },
+    });
+
+    expect(Select.vm.findOptionFromReducedValue(option)).toEqual(option);
+    expect(Select.vm.selectedValue).toEqual([option]);
+  });
+
   describe("And when a reduced option is a nested object", () => {
     it("can determine if an object is pre-selected", () => {
       const nestedOption = { value: { nested: true }, label: "foo" };

--- a/tests/unit/Reduce.spec.js
+++ b/tests/unit/Reduce.spec.js
@@ -152,6 +152,20 @@ describe("When reduce prop is defined", () => {
     );
   });
 
+  it('can work with falsey values', () => {
+    const option = {value: 0, label: 'No'};
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        reduce: option => option.value,
+        options: [option, {value: 1, label: 'Yes'}],
+        value: 0,
+      },
+    });
+
+    expect(Select.vm.findOptionFromReducedValue(option)).toEqual(option);
+    expect(Select.vm.selectedValue).toEqual([option]);
+  });
+
   describe("And when a reduced option is a nested object", () => {
     it("can determine if an object is pre-selected", () => {
       const nestedOption = { value: { nested: true }, label: "foo" };


### PR DESCRIPTION
Check for `this.value` to be `undefined` instead of null in the created hook.