### PR TITLE
fix unclosable select dropdown when clicking on dropdown

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -51,7 +51,7 @@
     </div>
 
     <transition :name="transition">
-      <ul ref="dropdownMenu" v-if="dropdownOpen" class="vs__dropdown-menu" role="listbox" @mousedown="onMousedown" @mouseup="onMouseUp">
+      <ul ref="dropdownMenu" v-if="dropdownOpen" class="vs__dropdown-menu" role="listbox" @mousedown.prevent="onMousedown" @mouseup="onMouseUp">
         <li
           role="option"
           v-for="(option, index) in filteredOptions"


### PR DESCRIPTION
The reason for the bug was: clicking on the area blurred the search
input. vue-slect relies on this event to close the dropdown.
Since the click happend inside the dropdown, it did not
close (which is correct). Though now the search input was blurred
already, so clicking outside of the dropdown had no effect. Be
preventing event propagation, the input does not get blurred anymore
when clicking inside the dropdown and everything still works.

unfortunately I didn't manage to write a unit spec for this, maybe somebody can help? Or just merge it without one if it is not so important.

---

Closes #948
Closes #932