### PR TITLE
Add 'compare' props

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -309,6 +309,19 @@
       },
 
       /**
+       * Callback to determine if the search text is exist in options with taggable.
+       * @type  {Function}
+       * @param {String} label
+       * @param {String} search
+       */
+      comparea: {
+        type: Function,
+        default(label, search) {
+          return label === search
+        }
+      },
+
+      /**
        * Set the tabindex for the input field.
        * @type {Number}
        */
@@ -728,10 +741,10 @@
        */
       optionExists(option) {
         return this.optionList.some(opt => {
-          if (typeof opt === 'object' && this.getOptionLabel(opt) === option) {
-            return true
+          if (typeof option === 'string') {
+            return this.comparea(this.getOptionLabel(opt), option)
           } else if (opt === option) {
-            return true
+            return opt === option
           }
           return false
         })


### PR DESCRIPTION
Fix issue similar #661 .

- default:
```js
// default
comparea(label, search) {
  return label === search
}
```
![image](https://user-images.githubusercontent.com/20247366/65825723-f25dda00-e2ac-11e9-90de-07c98b9250d8.png)

- with comparea
```js
//  ignore case 
comparea(search, label) => {
    return search.toLowerCase() === label.toLowerCase()
  }
```
![image](https://user-images.githubusercontent.com/20247366/65825731-07d30400-e2ad-11e9-92f8-fe6318195ada.png)

