### PR TITLE
Add selectOnCustom to override select keys

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -454,6 +454,15 @@
       searchInputQuerySelector: {
         type: String,
         default: '[type=search]'
+      },
+
+      /**
+       * Override keyCodes that triggers selection.
+       * Defaults to 13 (Enter.)
+       */
+      selectOnCustom: {
+        type: Array,
+        default: () => [13],
       }
     },
 
@@ -848,22 +857,30 @@
        * @return {Function}
        */
       onSearchKeyUp (e) {
-        switch (e.keyCode) {
-          case 27:
-            //  esc
-            return this.onEscape();
-          case 38:
-            //  up.prevent
-            e.preventDefault();
-            return this.typeAheadUp();
-          case 40:
-            //  down.prevent
-            e.preventDefault();
-            return this.typeAheadDown();
-          case 13:
-            //  enter.prevent
+        let codes = this.selectOnCustom;
+        if (!Array.isArray(codes)) {
+          codes = [codes];
+        }
+
+        if (codes.includes(e.keyCode)) {
+            //  prevent default and trigger select
             e.preventDefault();
             return this.typeAheadSelect();
+        } else {
+          switch (e.keyCode) {
+            case 27:
+              //  esc
+              return this.onEscape();
+            case 38:
+              //  up.prevent
+              e.preventDefault();
+              return this.typeAheadUp();
+            case 40:
+              //  down.prevent
+              e.preventDefault();
+              return this.typeAheadDown();
+            case 13:
+          }
         }
       }
     },

--- a/tests/unit/Selecting.spec.js
+++ b/tests/unit/Selecting.spec.js
@@ -63,6 +63,20 @@ describe("VS - Selecting Values", () => {
     expect(spy).toHaveBeenCalledWith();
   });
 
+  it("can select an option on space", () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        selectOnCustom: [32]
+      }
+    });
+
+    const spy = jest.spyOn(Select.vm, "typeAheadSelect");
+
+    Select.find({ ref: "search" }).trigger("keyup.space");
+
+    expect(spy).toHaveBeenCalledWith();
+  });
+
   it("can deselect a pre-selected object", () => {
     const Select = shallowMount(VueSelect, {
       propsData: {


### PR DESCRIPTION
This adds a new prop, `selectOnCustom`, where users can override the default key for triggering selection or add multiple keys. For example, For Issue #956, you could use `:select-on-custom="[13, 32]"`.

Let me know if there's other changes you'd like to see. Things that come to mind are

- We could likely simplify/deprecate `selectOnTab` to combine it with this functionality.
- I wonder if there's a reason `selectOnTab` is based on keydown, whereas all other bindings are based on keyup? Is that something we'd need to allow `selectOnCustom` to specify?