### PR TITLE
Fix unclickable dead zones around dropdown and dropdown arrow

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -28,7 +28,7 @@
         </slot>
       </div>
 
-      <div class="vs__actions">
+      <div class="vs__actions" ref="actions">
         <button
           v-show="showClearButton"
           :disabled="disabled"
@@ -620,6 +620,8 @@
           this.$el,
           this.searchEl,
           this.$refs.toggle,
+          this.$refs.actions,
+          this.$refs.selectedOptions,
         ];
 
         if (typeof this.$refs.openIndicator !== 'undefined') {


### PR DESCRIPTION
There is a thin space along the top of the select and large spaces above and below the arrow that are not clickable as mentioned in #947

![Unclickable Select](https://user-images.githubusercontent.com/199181/66707490-52259d80-ed0f-11e9-98bf-a18e018e2cfc.png)

I added 2 extra elements to the list of clickable targets for opening the select dropdown and I have not found any negative side effects, though I do not fully understand why the whitelist is there to start with.