### PR TITLE
Fix 969 add get selected option class

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -13,7 +13,7 @@
               :deselect="deselect"
               :multiple="multiple"
               :disabled="disabled">
-          <span :key="getOptionKey(option)" class="vs__selected">
+          <span :key="getOptionKey(option)" :class="getSelectedOptionClasses(option)">
             <slot name="selected-option" v-bind="normalizeOptionForSlot(option)">
               {{ getOptionLabel(option) }}
             </slot>
@@ -298,6 +298,24 @@
             }
           }
         }
+      },
+
+      /**
+       * Adjust the CSS classes applied to selected values.
+       */
+      getSelectedOptionClasses: {
+        type: Function,
+        /**
+         * Determines the classname for a given selected option. Receives the
+         * option as a parameter should return a valid class binding via a
+         * String, Object, or Array.
+         *
+         * @see https://vuejs.org/v2/guide/class-and-style.html
+         *
+         * @param option {Object|String|Number} An option that has been selected
+         * @return {Array|Object|String} Any valid VueJS class binding format.
+         */
+        default: option => ['vs__selected']
       },
 
       /**

--- a/tests/unit/Selecting.spec.js
+++ b/tests/unit/Selecting.spec.js
@@ -1,5 +1,6 @@
 import { mount, shallowMount } from "@vue/test-utils";
 import VueSelect from "../../src/components/Select.vue";
+import { mountDefault } from '../helpers';
 
 describe("VS - Selecting Values", () => {
   let defaultProps;
@@ -195,7 +196,7 @@ describe("VS - Selecting Values", () => {
     expect(Select.vm.isOptionSelected("foo")).toEqual(true);
   });
 
-  describe("change Event", () => {
+  describe("input Event", () => {
     it("will trigger the input event when the selection changes", () => {
       const Select = shallowMount(VueSelect);
       Select.vm.select("bar");
@@ -208,6 +209,23 @@ describe("VS - Selecting Values", () => {
       });
       Select.vm.select("bar");
       expect(Select.emitted("input")[0]).toEqual([["foo", "bar"]]);
+    });
+  });
+
+  describe('selected classes', () => {
+    it("adds the vs__selected class by default", () => {
+      const Select = mountDefault({value: 'one'});
+      expect(Select. contains('.vs__selected')).toBe(true);
+    });
+
+    it("can add a custom class using the getSelectedOptionClasses prop", () => {
+      const Select = mountDefault({
+        value: 'one',
+        getSelectedOptionClasses: option => ['vs__selected', `vs__selected--${option}`]
+      });
+      
+      expect(Select. contains('.vs__selected')).toBe(true);
+      expect(Select. contains('.vs__selected--one')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
It's currently really difficult to add a custom class to the `selected-option-container` slot. That slot needs to be refactored, and this prop provides a lightweight solution to custom classes for selected options in the meantime.

---

Closes #969 