### PR TITLE
Add NPM prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": false,
   "main": "dist/vue-select.js",
   "license": "MIT",
+  "prepare": "npm run build",
   "scripts": {
     "serve": "webpack-dev-server --config build/webpack.dev.conf.js --hot --progress -d",
     "serve:docs": "cd docs && yarn serve",


### PR DESCRIPTION
Should allow users to install from GitHub without requiring `/dist` to be returned to source.

Notes:

- doesn't work with `yarn` https://github.com/yarnpkg/yarn/issues/5235
- same implementation as vue-multiselect: https://github.com/shentao/vue-multiselect/pull/970.

---

Closes #908 