### PR TITLE
Fix Chrome search-cancel-button

### DIFF
--- a/src/scss/modules/_search-input.scss
+++ b/src/scss/modules/_search-input.scss
@@ -3,8 +3,16 @@
 $line-height: $vs-component-line-height;
 $font-size: 1em;
 
+/**
+ * Super weird bug... If this declaration is grouped
+ * below, the cancel button will still appear in chrome.
+ * If it's up here on it's own, it'll hide it.
+ */
+.vs__search::-webkit-search-cancel-button {
+  display: none;
+}
+
 .vs__search::-webkit-search-decoration,
-.vs__search::-webkit-search-cancel-button,
 .vs__search::-webkit-search-results-button,
 .vs__search::-webkit-search-results-decoration,
 .vs__search::-ms-clear {


### PR DESCRIPTION
```css
.vs__search::-webkit-search-cancel-button {
  display: none;
}
```

The above CSS has always existed, but it was part of a grouping:

```css
.vs__search::-webkit-search-decoration,
.vs__search::-webkit-search-cancel-button,
.vs__search::-webkit-search-results-button,
.vs__search::-webkit-search-results-decoration,
.vs__search::-ms-clear {
  display: none;
}
```

For some reason, chrome would ignore the declaration when it is grouped.

---

Closes #886