### PR TITLE
Prevent resetting when the options change to the same object

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -513,8 +513,10 @@
        * is correct.
        * @return {[type]} [description]
        */
-      options(val) {
-        if (!this.taggable && this.resetOnOptionsChange) {
+      options(val, oldVal) {
+        const hasChanged = JSON.stringify(val) !== JSON.stringify(oldVal);
+
+        if (!this.taggable && this.resetOnOptionsChange && hasChanged) {
           this.clearSelection()
         }
 

--- a/tests/unit/ReactiveOptions.spec.js
+++ b/tests/unit/ReactiveOptions.spec.js
@@ -24,6 +24,17 @@ describe("Reset on options change", () => {
     expect(Select.vm.selectedValue).toEqual([]);
   });
 
+  it("should not reset the selected value when the options property changes to the same object", () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: { resetOnOptionsChange: true, options: ["one"] }
+    });
+
+    Select.vm.$data._value = 'one';
+
+    Select.setProps({options: ["one"]});
+    expect(Select.vm.selectedValue).toEqual(["one"]);
+  });
+
   it("should return correct selected value when the options property changes and a new option matches", () => {
     const Select = shallowMount(VueSelect, {
       propsData: { value: "one", options: [], reduce(option) { return option.value } }


### PR DESCRIPTION
Hi!

When using the `resetOnOptionsChange` option, the value is reset even if the new options object contains the exact same set of items.

We are populating the options via an AJAX request, so technically yes they are different objects, but the actual options never changed.

This PR makes it so that it checks that it's actually changed.