### PR TITLE
Add push-tags prop to example snippet

### DIFF
--- a/docs/guide/values.md
+++ b/docs/guide/values.md
@@ -127,7 +127,7 @@ To allow input that's not present within the options, set the `taggable` prop to
 If you want added tags to be pushed to the options array, set `push-tags` to true.
 
 ```html
-<v-select taggable multiple />
+<v-select taggable multiple push-tags />
 ```
 
 <v-select taggable multiple push-tags />


### PR DESCRIPTION
Even though the example component does have the `push-tags` prop correctly set, it's missing from the example code

![Screenshot 2019-12-09 at 18 02 42](https://user-images.githubusercontent.com/9140811/70451523-2f64fa80-1aae-11ea-88ff-bc44de65c228.png)
