### PR TITLE
Display custom label in place of selected options

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -48,6 +48,17 @@ clearable: {
 },
 ```
 
+## customFieldLabel
+
+Custom field value to display in case of long or numerous values. Useful when you want to display the dropdown inline and can't have it wrap multiple lines.
+
+```js
+customFieldLabel: {
+	type: String,
+	default: ''
+},
+```
+
 ## maxHeight
 
 ::: warning Deprecated in `v2.x` & Removed in `v3.0`
@@ -340,10 +351,10 @@ createOption: {
 ## resetOnOptionsChange
 
 When false, updating the options will not reset the selected value.
- 
-Since `v3.4+` the prop accepts either a `boolean` or `function` that returns a `boolean`. 
 
-If defined as a function, it will receive the params listed below. 
+Since `v3.4+` the prop accepts either a `boolean` or `function` that returns a `boolean`.
+
+If defined as a function, it will receive the params listed below.
 
 ```js
 /**

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -7,21 +7,24 @@
     <div ref="toggle" @mousedown.prevent="toggleDropdown" class="vs__dropdown-toggle">
 
       <div class="vs__selected-options" ref="selectedOptions">
-        <slot v-for="option in selectedValue"
-              name="selected-option-container"
-              :option="normalizeOptionForSlot(option)"
-              :deselect="deselect"
-              :multiple="multiple"
-              :disabled="disabled">
-          <span :key="getOptionKey(option)" class="vs__selected">
-            <slot name="selected-option" v-bind="normalizeOptionForSlot(option)">
-              {{ getOptionLabel(option) }}
-            </slot>
-            <button v-if="multiple" :disabled="disabled" @click="deselect(option)" type="button" class="vs__deselect" aria-label="Deselect option" ref="deselectButtons">
-              <component :is="childComponents.Deselect" />
-            </button>
-          </span>
-        </slot>
+        <span class="vs__selected" v-if="customFieldLabel">{{ customFieldLabel }}</span>
+        <template v-else>
+          <slot v-for="option in selectedValue"
+                name="selected-option-container"
+                :option="normalizeOptionForSlot(option)"
+                :deselect="deselect"
+                :multiple="multiple"
+                :disabled="disabled">
+            <span :key="getOptionKey(option)" class="vs__selected">
+              <slot name="selected-option" v-bind="normalizeOptionForSlot(option)">
+                {{ getOptionLabel(option) }}
+              </slot>
+              <button v-if="multiple" :disabled="disabled" @click="deselect(option)" type="button" class="vs__deselect" aria-label="Deselect option" ref="deselectButtons">
+                <component :is="childComponents.Deselect" />
+              </button>
+            </span>
+          </slot>
+        </template>
 
         <slot name="search" v-bind="scope.search">
           <input class="vs__search" v-bind="scope.search.attributes" v-on="scope.search.events">
@@ -93,7 +96,7 @@
        * Contains the currently selected value. Very similar to a
        * `value` attribute on an <input>. You can listen for changes
        * using 'change' event using v-on
-       * @type {Object||String||null}
+       * @type {Object||Array||String||null}
        */
       value: {},
 
@@ -175,6 +178,15 @@
       transition: {
         type: String,
         default: 'vs__fade'
+      },
+
+      /**
+       * Optional custom field value to display in case of long or numerous values.
+       * @type {String}
+       */
+      customFieldLabel: {
+        type: String,
+        default: ''
       },
 
       /**
@@ -1024,7 +1036,7 @@
       stateClasses() {
         return {
           'vs--open': this.dropdownOpen,
-          'vs--single': !this.multiple,
+          'vs--single': !this.multiple || this.customFieldLabel,
           'vs--searching': this.searching && !this.noDrop,
           'vs--searchable': this.searchable && !this.noDrop,
           'vs--unsearchable': !this.searchable,

--- a/tests/unit/Labels.spec.js
+++ b/tests/unit/Labels.spec.js
@@ -1,3 +1,4 @@
+import Vue from 'vue'
 import VueSelect from "../../src/components/Select";
 import { shallowMount } from "@vue/test-utils";
 import { selectWithProps } from "../helpers";
@@ -13,7 +14,7 @@ describe("Labels", () => {
   });
 
   it("will console.warn when options contain objects without a valid label key", () => {
-    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => { });
     const Select = selectWithProps({
       options: [{}]
     });
@@ -21,7 +22,7 @@ describe("Labels", () => {
     Select.vm.open = true;
     expect(spy).toHaveBeenCalledWith(
       '[vue-select warn]: Label key "option.label" does not exist in options object {}.' +
-        "\nhttps://vue-select.org/api/props.html#getoptionlabel"
+      "\nhttps://vue-select.org/api/props.html#getoptionlabel"
     );
   });
 
@@ -38,5 +39,19 @@ describe("Labels", () => {
     expect(Select.vm.searchPlaceholder).toEqual("foo");
     Select.vm.$data._value = "one";
     expect(Select.vm.searchPlaceholder).not.toBeDefined();
+  });
+
+  it("should display a custom placeholder instead of selected values", async () => {
+    const customFieldLabel = "2 selected"
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        customFieldLabel,
+        options: ["one", "two", "three"]
+      }
+    });
+
+    Select.vm.$data._value = ["one", "three"];
+    await Vue.nextTick()
+    expect(Select.find(".vs__selected").text()).toEqual(customFieldLabel);
   });
 });


### PR DESCRIPTION
This PR resolves #1003 with an additional prop, whose textual value would override the `vs__selected-options` contents.

Maybe `collapseTags` would be a better name, seems that Element UI uses that as mentioned in https://github.com/sagalbot/vue-select/issues/1003#issuecomment-567502356

An example use case for this new prop would be:
```
<v-select
  v-model="userIds"
  label="name"
  placeholder="Everyone"
  :options="users"
  :customFieldLabel="userIds.length > 2 ? `${userIds.length} selected` : null"
  :reduce="option => option.id"
  :closeOnSelect="false"
  @search="getUsers"
/>
```

![custom-label](https://user-images.githubusercontent.com/9140811/71885757-acce6a00-3143-11ea-9a3a-f9e04c734662.gif)
