### PR TITLE
Emit input event only if there is val to be deleted

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -754,7 +754,7 @@
        * @return {this.value}
        */
       maybeDeleteValue() {
-        if (!this.searchEl.value.length && this.selectedValue && this.clearable) {
+        if (!this.searchEl.value.length && this.selectedValue && this.selectedValue.length && this.clearable) {
           let value = null;
           if (this.multiple) {
             value = [...this.selectedValue.slice(0, this.selectedValue.length - 1)]
@@ -882,7 +882,7 @@
         };
 
         const defaults = {
-          //  delete
+          //  backspace
           8: e => this.maybeDeleteValue(),
           //  tab
           9: e => this.onTab(),

--- a/tests/unit/Keydown.spec.js
+++ b/tests/unit/Keydown.spec.js
@@ -5,10 +5,10 @@ describe('Custom Keydown Handlers', () => {
   it('can use the map-keydown prop to trigger custom behaviour', () => {
     const onKeyDown = jest.fn();
     const Select = mountDefault({
-      mapKeydown: (defaults, vm) => ({...defaults, 32: onKeyDown}),
+      mapKeydown: (defaults, vm) => ({ ...defaults, 32: onKeyDown }),
     });
 
-    Select.find({ref: 'search'}).trigger('keydown.space');
+    Select.find({ ref: 'search' }).trigger('keydown.space');
 
     expect(onKeyDown.mock.calls.length).toBe(1);
   });
@@ -20,7 +20,7 @@ describe('Custom Keydown Handlers', () => {
 
     const spy = jest.spyOn(Select.vm, 'typeAheadSelect');
 
-    Select.find({ref: 'search'}).trigger('keydown.space');
+    Select.find({ ref: 'search' }).trigger('keydown.space');
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -28,16 +28,16 @@ describe('Custom Keydown Handlers', () => {
   it('even works when combining selectOnKeyCodes with map-keydown', () => {
     const onKeyDown = jest.fn();
     const Select = mountDefault({
-      mapKeydown: (defaults, vm) => ({...defaults, 32: onKeyDown}),
+      mapKeydown: (defaults, vm) => ({ ...defaults, 32: onKeyDown }),
       selectOnKeyCodes: [9],
     });
 
     const spy = jest.spyOn(Select.vm, 'typeAheadSelect');
 
-    Select.find({ref: 'search'}).trigger('keydown.space');
+    Select.find({ ref: 'search' }).trigger('keydown.space');
     expect(onKeyDown.mock.calls.length).toBe(1);
 
-    Select.find({ref: 'search'}).trigger('keydown.tab');
+    Select.find({ ref: 'search' }).trigger('keydown.tab');
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -47,28 +47,38 @@ describe('Custom Keydown Handlers', () => {
       const Select = mountDefault();
       const spy = jest.spyOn(Select.vm, 'typeAheadSelect');
 
-      Select.find({ref: 'search'}).trigger('compositionstart');
-      Select.find({ref: 'search'}).trigger('keydown.enter');
+      Select.find({ ref: 'search' }).trigger('compositionstart');
+      Select.find({ ref: 'search' }).trigger('keydown.enter');
       expect(spy).toHaveBeenCalledTimes(0);
 
-      Select.find({ref: 'search'}).trigger('compositionend');
-      Select.find({ref: 'search'}).trigger('keydown.enter');
+      Select.find({ ref: 'search' }).trigger('compositionend');
+      Select.find({ ref: 'search' }).trigger('keydown.enter');
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('will not select a value with tab if the user is composing', () => {
-      const Select = mountDefault({selectOnTab: true});
+      const Select = mountDefault({ selectOnTab: true });
       const spy = jest.spyOn(Select.vm, 'typeAheadSelect');
 
-      Select.find({ref: 'search'}).trigger('compositionstart');
-      Select.find({ref: 'search'}).trigger('keydown.tab');
+      Select.find({ ref: 'search' }).trigger('compositionstart');
+      Select.find({ ref: 'search' }).trigger('keydown.tab');
       expect(spy).toHaveBeenCalledTimes(0);
 
-      Select.find({ref: 'search'}).trigger('compositionend');
-      Select.find({ref: 'search'}).trigger('keydown.tab');
+      Select.find({ ref: 'search' }).trigger('compositionend');
+      Select.find({ ref: 'search' }).trigger('keydown.tab');
       expect(spy).toHaveBeenCalledTimes(1);
     });
 
+    it('will not emit input event if value has not changed with backspace', () => {
+      const Select = mountDefault();
+      Select.vm.$data._value = 'one';
+      Select.find({ ref: 'search' }).trigger('keydown.backspace');
+      expect(Select.emitted().input.length).toBe(1);
+
+      Select.find({ ref: 'search' }).trigger('keydown.backspace');
+      Select.find({ ref: 'search' }).trigger('keydown.backspace');
+      expect(Select.emitted().input.length).toBe(1);
+    });
   });
 
 });


### PR DESCRIPTION
The component emitted redundant `input` events for backspace when the field had no value. This is a potential DDoS vector for all AJAX use-cases of this component, as you can cause a hefty amount of requests within a mere second.

This fix adds a length check to `selectedValue`, which prevents the `input` event from being emitted once the field is empty.

You can check the current bug on the `master` branch in the sandbox locally (so Vue dev-tools are enabled) in the Event tab. Focus the field and hold down `Backspace` for 1-2 seconds. Hundreds of requests are made.

Current behaviour:

![backspace-input-broken](https://user-images.githubusercontent.com/9140811/72064285-39b02980-32e4-11ea-815c-d9203d48e5eb.gif)

Fixed behaviour (I held down the backspace for ~2-3s here)

![backspace-emit-fixed](https://user-images.githubusercontent.com/9140811/72064318-49c80900-32e4-11ea-8681-0c5bf63ab916.gif)
