### PR TITLE
* Add preselectOnHover and openOnlyOnSearch for better performances o…

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
       "html",
       "text-summary"
     ]
+  },
+  "dependencies": {
+    "fuse.js": "^3.4.6"
   }
 }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -58,8 +58,8 @@
           v-for="(option, index) in filteredOptions"
           :key="getOptionKey(option)"
           class="vs__dropdown-option"
-          :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer, 'vs__dropdown-option--disabled': !selectable(option) }"
-          @mouseover="selectable(option) ? typeAheadPointer = index : null"
+          :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer, 'vs__dropdown-option--disabled': !selectable(option), 'vs__dropdown-option--simpleHover': !preselectOnHover }"
+          @mouseover="preselectOnHover && selectable(option) ? typeAheadPointer = index : null"
           @mousedown.prevent.stop="selectable(option) ? select(option) : null"
         >
           <slot name="option" v-bind="normalizeOptionForSlot(option)">
@@ -500,6 +500,27 @@
          * @return {Object}
          */
         default: (map, vm) => map,
+      },
+
+      /**
+       * Disable pre-selection of the option on hover and
+       * enable a simpler, native CSS hover effect. Greatly
+       * improve performances for big options lists.
+       * @type {Boolean}
+       */
+      preselectOnHover: {
+        type: Boolean,
+        default: true
+      },
+
+      /**
+       * Open the drop-down only when searching a few
+       * keystrokes. Useful for big options lists.
+       * @type {Boolean}
+       */
+      openOnlyOnSearch: {
+        type: Boolean,
+        default: false
       }
     },
 
@@ -1056,7 +1077,7 @@
        * @return {Boolean} True if open
        */
       dropdownOpen() {
-        return this.noDrop ? false : this.open && !this.mutableLoading
+        return this.noDrop ? false : (this.open && !this.mutableLoading && (!this.openOnlyOnSearch || this.searching))
       },
 
       /**

--- a/src/scss/modules/_dropdown-option.scss
+++ b/src/scss/modules/_dropdown-option.scss
@@ -12,7 +12,8 @@
   }
 }
 
-.vs__dropdown-option--highlight {
+.vs__dropdown-option--highlight,
+.vs__dropdown-option--simpleHover:hover {
   background: $vs-state-active-bg;
   color: $vs-state-active-color;
 }

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -164,4 +164,24 @@ describe("Toggling Dropdown", () => {
     expect(Select.classes('vs--searching')).toBeFalsy();
   });
 
+  it("should not display the dropdown if openOnlyOnSearch is true and no search is active", () => {
+    const Select = selectWithProps({
+      openOnlyOnSearch: true
+    });
+
+    Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
+    expect(Select.vm.open).toEqual(true);
+    expect(Select.contains('.vs__dropdown-menu')).toBeFalsy();
+    expect(Select.vm.stateClasses['vs--open']).toBeFalsy();
+  });
+
+  it("should display the dropdown if openOnlyOnSearch is true and a search is active", () => {
+    const Select = selectWithProps({
+      openOnlyOnSearch: true
+    });
+
+    Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
+    Select.vm.search = "foo";
+    expect(Select.vm.stateClasses['vs--open']).toEqual(true);
+  });
 });


### PR DESCRIPTION
…n huge select lists.

      /**
       * Disable pre-selection of the option on hover and
       * enable a simpler, native CSS hover effect. Greatly
       * improve performances for big options lists.
       * @type {Boolean}
       */
      preselectOnHover: {
        type: Boolean,
        default: true
      },

      /**
       * Open the drop-down only when searching a few
       * keystrokes. Useful for big options lists.
       * @type {Boolean}
       */
      openOnlyOnSearch: {
        type: Boolean,
        default: false
      }