### PR TITLE
feat: add dropRenderingMode prop

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -369,6 +369,20 @@ noDrop: {
 },
 ```
 
+## dropRenderingMode
+
+Determines rendering mode for the dropdown ('v-if' or 'v-show').
+
+```js
+dropRenderingMode: {
+	type: String,
+	default: 'v-if',
+	validator(value) {
+		return value === 'v-if' || value === 'v-show';
+	}
+},
+```
+
 ## inputId
 
 Sets the id of the input element.

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -52,7 +52,15 @@
     </div>
 
     <transition :name="transition">
-      <ul ref="dropdownMenu" v-if="dropdownOpen" class="vs__dropdown-menu" role="listbox" @mousedown.prevent="onMousedown" @mouseup="onMouseUp">
+      <ul
+        ref="dropdownMenu"
+        v-if="dropdownOpen || dropRenderingMode === 'v-show'"
+        v-show="dropdownOpen || dropRenderingMode === 'v-if'"
+        class="vs__dropdown-menu"
+        role="listbox"
+        @mousedown.prevent="onMousedown"
+        @mouseup="onMouseUp"
+      >
         <li
           role="option"
           v-for="(option, index) in filteredOptions"
@@ -432,6 +440,19 @@
       noDrop: {
         type: Boolean,
         default: false
+      },
+
+      /**
+       * Determines rendering mode for the dropdown ('v-if' or 'v-show').
+       * @type {String}
+       * @default 'v-if'
+       */
+      dropRenderingMode: {
+        type: String,
+        default: 'v-if',
+        validator(value) {
+          return value === 'v-if' || value === 'v-show';
+        }
       },
 
       /**

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -164,4 +164,28 @@ describe("Toggling Dropdown", () => {
     expect(Select.classes('vs--searching')).toBeFalsy();
   });
 
+  it("should render the dropdown when dropRenderingMode is 'v-show' even if it is closed", () => {
+    const Select = selectWithProps({
+      dropRenderingMode: 'v-show',
+    });
+
+    expect(Select.vm.$refs.dropdownMenu).toBeDefined();
+  });
+
+  it("should hide the dropdown when it is closed and dropRenderingMode is 'v-show'", () => {
+    const Select = selectWithProps({
+      dropRenderingMode: 'v-show',
+    });
+
+    const display = getComputedStyle(Select.vm.$refs.dropdownMenu).display;
+    expect(display).toStrictEqual('none');
+  });
+
+  it("should NOT render the dropdown when it is closed and dropRenderingMode is 'v-if'", () => {
+    const Select = selectWithProps({
+      dropRenderingMode: 'v-if',
+    });
+
+    expect(Select.vm.$refs.dropdownMenu).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Use cases:
* The options list is heavy and it is better to render it once rather than on each open.
* The user wants the width of the field to be no more than the width of the widest option, so it does not change when another option is selected.
This can be achieved by keeping the dropdown in the DOM at all times and keeping its `position` `static`.