### PR TITLE
Improved Focusing, $el as a button

### DIFF
--- a/dev/Dev.vue
+++ b/dev/Dev.vue
@@ -1,19 +1,42 @@
 <template>
-  <div id="app">
-    <sandbox hide-help v-slot="config">
-      <v-select v-bind="config"/>
-    </sandbox>
-  </div>
+  <!--  <div id="app">-->
+  <!--    <sandbox hide-help v-slot="config">-->
+  <!--      <v-select v-bind="config"/>-->
+  <!--    </sandbox>-->
+  <!--  </div>-->
+  <form>
+    <label for="name">Name</label>
+    <input type="text" id="name" autofocus>
+
+    <label for="email">eMail</label>
+    <input type="email" id="email">
+
+    <label for="emails">eMail</label>
+    <select id="emails">
+      <option value="one">one</option>
+      <option value="two">two</option>
+    </select>
+
+    <label for="country">Country</label>
+    <v-select :options="countries" id="country" :filterable="false" />
+
+    <label for="hello">Hello</label>
+    <input type="text" id="hello">
+  </form>
 </template>
 
 <script>
 import vSelect from '../src/components/Select';
 import Sandbox from '../docs/.vuepress/components/Sandbox';
-// import countries from '../docs/.vuepress/data/countryCodes';
-// import books from '../docs/.vuepress/data/books';
+import countries from '../docs/.vuepress/data/countryCodes';
+import books from '../docs/.vuepress/data/books';
 
 export default {
   components: {Sandbox, vSelect},
+  computed: {
+    countries: () => countries,
+    books: () => books,
+  }
 };
 </script>
 
@@ -35,5 +58,21 @@ export default {
     margin-bottom: 1em;
     padding-top: 1em;
     width: 90%;
+  }
+
+  form {
+    width: 500px;
+    margin: 0 auto;
+    padding-top: 5rem;
+  }
+
+  label {
+    width:100%;
+    display: block;
+    margin-top:1rem;
+  }
+
+  input {
+    width: 100%;
   }
 </style>

--- a/src/scss/modules/_dropdown-toggle.scss
+++ b/src/scss/modules/_dropdown-toggle.scss
@@ -18,6 +18,7 @@ $border-radius: $vs-border-radius;
 .vs__dropdown-toggle {
   appearance: none;
   display: flex;
+  width: 100%;
   padding: 0 0 4px 0;
   background: none;
   border: $border-width $border-style $border-color;

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -1,10 +1,25 @@
-import { selectWithProps } from "../helpers";
+import { mountDefault, selectWithProps } from '../helpers';
 import OpenIndicator from "../../src/components/OpenIndicator";
 
 describe("Toggling Dropdown", () => {
+  fdescribe('focusing on the button wrapper', () => {
+    test('when the search is focused buttonIsFocused is false', () => {
+      const Select = mountDefault();
+      Select.vm.$refs.search.focus();
+      expect(Select.vm.buttonIsFocused).toBeFalsy();
+    })
+
+    test('when the button is focused, buttonIsFocused is true', async () => {
+      const Select = mountDefault();
+      Select.vm.$refs.toggle.focus();
+      await Select.vm.$nextTick();
+      expect(Select.vm.buttonIsFocused).toBeTruthy();
+    })
+  });
+
   it("should not open the dropdown when the el is clicked but the component is disabled", () => {
     const Select = selectWithProps({ disabled: true });
-    Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
+    Select.vm.maybeToggleDropdown({ target: Select.vm.$refs.search });
     expect(Select.vm.open).toEqual(false);
   });
 
@@ -14,7 +29,7 @@ describe("Toggling Dropdown", () => {
       options: [{ label: "one" }]
     });
 
-    Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
+    Select.vm.maybeToggleDropdown({ target: Select.vm.$refs.search });
     expect(Select.vm.open).toEqual(true);
   });
 
@@ -26,7 +41,7 @@ describe("Toggling Dropdown", () => {
 
     const selectedTag = Select.find(".vs__selected").element;
 
-    Select.vm.toggleDropdown({ target: selectedTag });
+    Select.vm.maybeToggleDropdown({ target: selectedTag });
     expect(Select.vm.open).toEqual(true);
   });
 
@@ -35,7 +50,7 @@ describe("Toggling Dropdown", () => {
     const spy = jest.spyOn(Select.vm.$refs.search, "blur");
 
     Select.vm.open = true;
-    Select.vm.toggleDropdown({ target: Select.vm.$el });
+    Select.vm.maybeToggleDropdown({ target: Select.vm.$el });
 
     expect(spy).toHaveBeenCalled();
   });
@@ -134,7 +149,7 @@ describe("Toggling Dropdown", () => {
       noDrop: true,
     });
 
-    Select.vm.toggleDropdown({ target: Select.vm.$refs.search });
+    Select.vm.maybeToggleDropdown({ target: Select.vm.$refs.search });
     expect(Select.vm.open).toEqual(true);
     expect(Select.contains('.vs__dropdown-menu')).toBeFalsy();
     expect(Select.vm.stateClasses['vs--open']).toBeFalsy();


### PR DESCRIPTION
Updates the root $el to be a focusable button instead of a div. Allows for separating focusing of the component from opening the dropdown.

![Feb-15-2020 11-32-47](https://user-images.githubusercontent.com/692538/74594069-f3d33900-4fe6-11ea-92ae-2ca28f65c598.gif)

Closes #1054 

---


- [x] swap root $el for button
- [ ] implement button keypress handler
- - implementation should mimic native `<select>`
- - [ ] space should open dropdown, but not enter the character to search
- - [ ] return does nothing
- - [ ] modifier keys don't toggle the dropdown
- - [ ] up/down toggles dropdown, doesn't adjust typeahead index
- - [ ] left/right selects the next option in either direction
- - - [ ] left/right doesn't loop the list, stops at first and last
- [ ] update dropdown tests
