### PR TITLE
new option - preserveSelectedText

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -485,6 +485,15 @@
       },
 
       /**
+       * Enables/disables updating the search text to the last selected value when the dropdown is opened.
+       * @type {Boolean}
+       */
+      preserveSelectedText: {
+        type: Boolean,
+        default: false
+      },
+
+    /**
        * Query Selector used to find the search input
        * when the 'search' scoped slot is used.
        *
@@ -859,6 +868,10 @@
       onSearchFocus() {
         this.open = true
         this.$emit('search:focus')
+
+        if (!this.multiple && this.preserveSelectedText) {
+          this.search = (this.value || {})[this.label] || ''
+        }
       },
 
       /**


### PR DESCRIPTION
Summary:
Adds a configurable option to allow the search text to automatically be populated with the selected value when the dropdown is opened.

Purpose of this feature:
There are instances where users may want to immediately re-select the value or perform another search by taking off a letter at the end of the selected item, for example, or any number of additional reasons the user just wants to interact more directly with the value that they chose (or pre-populated in the data model).  Note, this feature is complementary to https://github.com/sagalbot/vue-select/pull/1092 and with both options enabled allows for much more fluid interactions with the control.

This feature is flag-enabled and does not break any default functionality.

Please let me know if there is anything needed to improve naming conventions or if I missed any edge cases, thanks!