### PR TITLE
feat: add open & close events

### DIFF
--- a/docs/.vuepress/components/InfiniteScroll.vue
+++ b/docs/.vuepress/components/InfiniteScroll.vue
@@ -1,0 +1,56 @@
+<template>
+  <v-select :options="countries" @open="onOpen" @close="onClose">
+    <template #list-footer v-if="hasNextPage">
+      <li ref="load">Loading more options...</li>
+    </template>
+  </v-select>
+</template>
+
+<script>
+import vSelect from '../../../src/components/Select'
+import countries from '../data/countries';
+
+export default {
+  components: {vSelect},
+  name: "InfiniteScroll",
+  data: () => ({observer: null, limit: 10}),
+  computed: {
+    countries () {
+      return countries.slice(0, this.limit);
+    },
+    hasNextPage () {
+      return this.countries.length < countries.length;
+    },
+  },
+  mounted () {
+    this.observer = new IntersectionObserver(this.infiniteScroll, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0
+    });
+  },
+  methods: {
+    async onOpen () {
+      if (this.hasNextPage) {
+        await this.$nextTick();
+        this.observer.observe(this.$refs.load)
+      }
+    },
+    onClose () {
+      this.observer.disconnect();
+    },
+    async infiniteScroll ([{isIntersecting, target}]) {
+      if (isIntersecting) {
+        const scrollTop = target.offsetParent.scrollTop;
+        this.limit += 10;
+        await this.$nextTick();
+        target.offsetParent.scrollTop = scrollTop;
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -120,6 +120,7 @@ module.exports = {
             ['guide/validation', 'Validation'],
             ['guide/selectable', 'Limiting Selections'],
             ['guide/pagination', 'Pagination'],
+            ['guide/infinite-scroll', 'Infinite Scroll'],
             ['guide/vuex', 'Vuex'],
             ['guide/ajax', 'AJAX'],
             ['guide/loops', 'Using in Loops'],

--- a/docs/guide/infinite-scroll.md
+++ b/docs/guide/infinite-scroll.md
@@ -1,0 +1,23 @@
+Vue Select doesn't ship with first party support for infinite scroll, but it's possible to implement
+by hooking into the `open`, `close`, and `search` events, along with the `filterable` prop, and the
+`list-footer` slot.
+
+Let's break down the example below, starting with the `data`.
+
+- `observer` - when the component is mounted, a new `IntersectionObserver` will be set here
+- `limit` - the number of options to display 'per page'
+- `search` - since we've disabled Vue Selects filtering, we'll need to filter options ourselves
+
+When Vue Select opens, the `open` event is emitted and `onOpen` will be called. We wait for
+`$nextTick()` so that the `$ref` we need will exist, then begin observing it for intersection.
+
+The observer is set to call `infiniteScroll` when the `<li>` is completely visible within the list.
+Some fancy destructuring is done here to get the first `ObservedEntry`, and specifically the
+`isIntersecting` & `target` properties. If the `<li>` is intersecting, we increase the `limit`, and
+ensure that the scroll position remains where it was before the list size changed. Again, it's
+important to wait for `$nextTick` here so that the DOM elements have been inserted before setting
+the scroll position.
+
+<InfiniteScroll />
+
+<<< @/.vuepress/components/InfiniteScroll.vue

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -619,6 +619,10 @@
        */
       multiple() {
         this.clearSelection()
+      },
+
+      open(isOpen) {
+        this.$emit(isOpen ? 'open' : 'close');
       }
     },
 


### PR DESCRIPTION
- Adds the `open` & `close` event triggered when the dropdown opens or closes
- Adds an infinite scroll example to the docs

---

Closes #1013 
Closes #916 
Closes #812 