### PR TITLE
fixed: don't prevent mousedown event on no-option.

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -70,7 +70,7 @@
             {{ getOptionLabel(option) }}
           </slot>
         </li>
-        <li v-if="filteredOptions.length === 0" class="vs__no-options" @mousedown.stop="">
+        <li v-if="filteredOptions.length === 0" class="vs__no-options">
           <slot name="no-options" v-bind="scope.noOptions">Sorry, no matching options.</slot>
         </li>
         <slot name="list-footer" v-bind="scope.listFooter" />


### PR DESCRIPTION
Fixes #1116. 