### PR TITLE
Check before accessing offsetHeight.

### DIFF
--- a/src/mixins/pointerScroll.js
+++ b/src/mixins/pointerScroll.js
@@ -32,8 +32,10 @@ export default {
       let pixelsToPointerTop = 0;
       if (this.$refs.dropdownMenu && this.dropdownOpen) {
         for (let i = 0; i < this.typeAheadPointer; i++) {
-          pixelsToPointerTop += this.$refs.dropdownMenu.children[i]
+          if (this.$refs.dropdownMenu.children[i]) {
+            pixelsToPointerTop += this.$refs.dropdownMenu.children[i]
             .offsetHeight;
+          }
         }
       }
       return pixelsToPointerTop;


### PR DESCRIPTION
I think I've found a bug with using the "selectable" prop. If you start typing text that only matches an option that has been set to not selectable, then press tab, I get this error: "Cannot read property 'offsetHeight' of undefined".

My fix just puts an if statement around reading the "offsetHeight" property.