### PR TITLE
fix: fix keyboard option navigation skipping all items

### DIFF
--- a/src/mixins/typeAheadPointer.js
+++ b/src/mixins/typeAheadPointer.js
@@ -26,6 +26,7 @@ export default {
       for (let i = this.typeAheadPointer - 1; i >= 0; i--) {
         if (this.selectable(this.filteredOptions[i])) {
           this.typeAheadPointer = i;
+          break;
         }
       }
     },
@@ -39,6 +40,7 @@ export default {
       for (let i = this.typeAheadPointer + 1; i < this.filteredOptions.length; i++) {
         if (this.selectable(this.filteredOptions[i])) {
           this.typeAheadPointer = i;
+          break;
         }
       }
     },


### PR DESCRIPTION
Fixes #1161. Navigating with up or down arrows would always go to first and last option, skipping
everything in between. Caused by missing break statements, probably deleted by accident.
