### PR TITLE
Do not show cursor as pointer when unsearchable select is disabled

### DIFF
--- a/src/scss/modules/_search-input.scss
+++ b/src/scss/modules/_search-input.scss
@@ -48,10 +48,9 @@ $font-size: 1em;
 .vs--unsearchable {
   .vs__search {
     opacity: 1;
-
-    &:hover {
-      cursor: pointer;
-    }
+  }
+  &:not(.vs--disabled) .vs__search:hover {
+    cursor: pointer;
   }
 }
 // Single, when searching but not loading or open


### PR DESCRIPTION
**Current Behaviour:**
When hovering a disabled and unsearchable select the cursor is different depending on the hovered area. When hovering the controls, the cursor will be a `not-allowed` one. When hovering the content, the cursor will be a `pointer`.

![IMG_6734](https://user-images.githubusercontent.com/35852798/80080474-fa83ac80-8551-11ea-98ac-98481f819a99.JPG)
![IMG_6733](https://user-images.githubusercontent.com/35852798/80080478-fc4d7000-8551-11ea-9bf5-88fe9b772a96.JPG)

**Expected Behaviour:**
In both cases, the cursor should be set to `not-allowed`.
