### PR TITLE
do not set $data._value in updateValue if reduce option is set, it is…

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -713,7 +713,7 @@
        * @param value
        */
       updateValue (value) {
-        if (this.isTrackingValues) {
+        if (typeof this.value === 'undefined') {
           // Vue select has to manage value
           this.$data._value = value;
         }
@@ -989,7 +989,6 @@
        */
       selectedValue () {
         let value = this.value;
-
         if (this.isTrackingValues) {
           // Vue select has to manage value internally
           value = this.$data._value;


### PR DESCRIPTION
… set by the watcher of value

if the parent denies to set an option, vue-select will still have the value stored (setted in updateValue()).
i also extended the v-model test in the Reduce spec

maybe fixes #1209 (could u test @himat ?)

---

Closes #1209 