### PR TITLE
updates to implementation of allowing mouse input on search field

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -752,7 +752,10 @@
           return;
         }
 
-        if (this.open && targetIsNotSearch) {
+        const targetIsNotSelectedItem = !event.target.classList.contains('vs__selected')
+        if (this.open &&
+          // do not close the menu if clicking on search box or a selected item
+          targetIsNotSearch && targetIsNotSelectedItem) {
           this.searchEl.blur();
         } else if (!this.disabled) {
           this.open = true;

--- a/src/scss/modules/_search-input.scss
+++ b/src/scss/modules/_search-input.scss
@@ -34,7 +34,7 @@ $font-size: 1em;
   width: 0;
   max-width: 100%;
   flex-grow: 1;
-  z-index: 1;
+  z-index: 0;
 }
 
 .vs__search::placeholder {

--- a/src/scss/modules/_selected.scss
+++ b/src/scss/modules/_selected.scss
@@ -9,7 +9,7 @@
   line-height: $vs-component-line-height;
   margin: 4px 2px 0px 2px;
   padding: 0 0.25em;
-  z-index: 0;
+  z-index: 1;
 }
 
 .vs__deselect {

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -4,7 +4,7 @@ import OpenIndicator from "../../src/components/OpenIndicator";
 const preventDefault = jest.fn()
 
 function clickEvent (currentTarget) {
-  return { currentTarget, preventDefault }
+  return { currentTarget, preventDefault, target: currentTarget }
 }
 
 describe("Toggling Dropdown", () => {
@@ -24,11 +24,10 @@ describe("Toggling Dropdown", () => {
     expect(Select.vm.open).toEqual(true);
   });
 
-  it("should not close the dropdown when the el is clicked and enableMouseInputSearch is set to true", () => {
+  it("should not close the dropdown when the Search element is clicked", () => {
     const Select = selectWithProps({
       value: [{ label: "one" }],
       options: [{ label: "one" }],
-      enableMouseSearchInput: true
     });
 
     Select.vm.toggleDropdown(clickEvent(Select.vm.$refs.search));


### PR DESCRIPTION
Purpose of this PR:
This updated implementation allows the user to click on the selected item(s) allowing for events to fire in situations involving templates.  Prior to this, the search field was reordered to allow it to cover the selected items and stop the click events intentionally.

Unit tests are also updated to reflect the logic in place.