### PR TITLE
IE compatibility for appendToBody

### DIFF
--- a/src/directives/appendToBody.js
+++ b/src/directives/appendToBody.js
@@ -2,11 +2,12 @@ export default {
     inserted (el, bindings, {context}) {
         if (context.appendToBody) {
             const {height, top, left, width} = context.$refs.toggle.getBoundingClientRect();
-
+            let scrollX = window.scrollX || window.pageXOffset;
+            let scrollY = window.scrollY || window.pageYOffset;
             el.unbindPosition = context.calculatePosition(el, context, {
                 width: width + 'px',
-                top: (window.scrollY + top + height) + 'px',
-                left: (window.scrollX + left) + 'px',
+                top: (scrollX + top + height) + 'px',
+                left: (scrollY + left) + 'px',
             });
 
             document.body.appendChild(el);


### PR DESCRIPTION
add a check for the IE implementation of scroll window variables so that the appendToBody Directive is compatible with IE 11.

Currently the appendToBody functionality doesn't work on IE because it doesn't check for the IE implementation of window scroll variables. 

Idk, if this project is supposed to be compatible with IE but i've found that it is when transpiled, except here. 