### PR TITLE
feat: add clearButtonTabIndex prop

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -339,6 +339,17 @@ tabindex: {
 },
 ```
 
+## clearButtonTabIndex
+
+Set the tabindex for the clear button.
+
+```js
+clearButtonTabIndex: {
+	type: Number,
+	default: -1
+},
+```
+
 ## pushTags
 
 When true, newly created tags will be added to

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -35,6 +35,7 @@
           :disabled="disabled"
           @click="clearSelection"
           type="button"
+          :tabindex="clearButtonTabIndex"
           class="vs__clear"
           title="Clear Selected"
           aria-label="Clear Selected"
@@ -101,6 +102,18 @@
     directives: {appendToBody},
 
     props: {
+      /**
+       * Control the tabindex for the clear button.
+       * Useful in situations where you might want
+       * tab to focus the clear button instead of
+       * moving to the next element.
+       * @type {Boolean}
+       */
+      clearButtonTabIndex: {
+        type: Number,
+        default: -1
+      },
+
       /**
        * Contains the currently selected value. Very similar to a
        * `value` attribute on an <input>. You can listen for changes


### PR DESCRIPTION
This should solve https://github.com/sagalbot/vue-select/issues/1145#issuecomment-645836997 

I couldn't figure out the significance between the Vue update and this issue coming up, but I made this PR anyway because it seemed like something you might want to control. This is also keeping one of my projects locked on Vue 2.5, believe it or not. 

Alternatively, we could just have the tabindex on the clear button be -1 and not add any unnecessary props. 

And unfortunately, I just can't get my head around testing and Vue. Let me know if you would want a test for this and I'm sure I could figure something out.  