### PR TITLE
fix guide for infiniteScroll.vue

### DIFF
--- a/docs/.vuepress/components/InfiniteScroll.vue
+++ b/docs/.vuepress/components/InfiniteScroll.vue
@@ -6,8 +6,8 @@
     @close="onClose"
     @search="query => search = query"
   >
-    <template #list-footer v-if="hasNextPage">
-      <li ref="load" class="loader">
+    <template #list-footer>
+      <li ref="load" class="loader" v-show="hasNextPage">
         Loading more options...
       </li>
     </template>


### PR DESCRIPTION
change the display condition of ther loader from v-if to v-show. When used with v-if and if returns false, the element will not be rendered and the observer stops working. With v-show, the element will exists but won't be visible and the observer will still work.

To reproduce the error:
- Open the select on guide/infinite scroll
- filter to anything that filters to an empty array, so ref="load" wont get rendered
- clear the filter, so the country array is back
- try to scroll
- infiniteScroll wont load more options and "Loading more options" will be visible