### PR TITLE
fix(select.vue): keep the dropdown open on custom slot input keydown

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -735,7 +735,7 @@
        * @return {void}
        */
       toggleDropdown (event) {
-        const targetIsNotSearch = event.target !== this.$refs.search;
+        const targetIsNotSearch = event.target !== this.searchEl;
         if (targetIsNotSearch) {
           event.preventDefault();
         }


### PR DESCRIPTION
Issue - When using custom search slot, to [enable placeholder](https://github.com/sagalbot/vue-select/issues/1039), the dopdown gets toggled while clicking on search input.

cause - the function `toggleDropdown` was checking only the default element reference.

fix - used existing computer prop to get the correct search input. 
