### PR TITLE
feat: Set search value to option selected if sync prop is given

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -540,6 +540,18 @@
       },
 
       /**
+       * Sets the value of the currently selected option
+       * onto the input box
+       *
+       * Applicable only for single select
+       * @type {Boolean}
+       */
+      syncSearchValue: {
+        type: Boolean,
+        default: false
+      },
+
+      /**
        * When `appendToBody` is true, this function is responsible for
        * positioning the drop down list.
        *
@@ -609,6 +621,7 @@
         if (this.isTrackingValues) {
           this.setInternalValueFromOptions(val)
         }
+        this.setSearchValue(val);
       },
 
       /**
@@ -634,6 +647,10 @@
       }
 
       this.$on('option:created', this.pushTag)
+    },
+
+    mounted() {
+      this.setSearchValue(this.value);
     },
 
     methods: {
@@ -680,12 +697,19 @@
         }));
       },
 
+      setSearchValue(val) {
+        if (this.syncSearchValue && !this.multiple && val) {
+          this.search = this.getOptionLabel(val);
+        }
+      },
+
       /**
        * Clears the currently selected value(s)
        * @return {void}
        */
       clearSelection() {
         this.updateValue(this.multiple ? [] : null)
+        this.search = '';
       },
 
       /**
@@ -699,7 +723,9 @@
           this.searchEl.blur()
         }
 
-        if (this.clearSearchOnSelect) {
+        if (this.syncSearchValue && !this.isMultiple) {
+          this.search = this.getOptionLabel(option);
+        } else if (this.clearSearchOnSelect) {
           this.search = ''
         }
       },

--- a/tests/unit/Layout.spec.js
+++ b/tests/unit/Layout.spec.js
@@ -27,4 +27,22 @@ describe("Single value options", () => {
     Select.vm.onSearchBlur();
     expect(Select.vm.search).toEqual("t");
   });
+
+  it("should set the search text as option when syncSearchValue is true", () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        value: "one",
+        syncSearchValue: true,
+        options: ["one", "two", "three"],
+      }
+    });
+
+    expect(Select.vm.syncSearchValue).toEqual(true);
+
+    Select.vm.open = true;
+    expect(Select.vm.search).toEqual("one");
+
+    Select.vm.onAfterSelect("two");
+    expect(Select.vm.search).toEqual("two");
+  });
 });


### PR DESCRIPTION
Fixes #1188 
Added new prop `syncSearchValue`.
In single select, if the prop is set, then 

-  when the user clicks on an option from dropdown, the search value is set to the value of that option.
-  On mount, if a default value is passed in, then that value will be set as the search value.
- Clearing the select will clear the search as well.

This fix along with `clearOnSelect` prop can be used to implement the required feature mentioned in #1188 