### PR TITLE
fix(vue3): Vue 3 Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
     "type": "git",
     "url": "https://github.com/sagalbot/vue-select.git"
   },
-  "peerDependencies": {
-    "vue": "2.x"
-  },
   "resolutions": {
     "ajv": "6.8.1"
   },


### PR DESCRIPTION
- [x] drops vue 2.x peerdep
- [ ] implement global API updates ex) `Uncaught TypeError: this.$on is not a function`