### PR TITLE
Add tabindex="-1" to vs__dropdown-menu to stop scrollbars receiving focus

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -53,7 +53,7 @@
       </div>
     </div>
     <transition :name="transition">
-      <ul ref="dropdownMenu" v-if="dropdownOpen" :id="`vs${uid}__listbox`" :key="`vs${uid}__listbox`" class="vs__dropdown-menu" role="listbox" @mousedown.prevent="onMousedown" @mouseup="onMouseUp" v-append-to-body>
+      <ul ref="dropdownMenu" v-if="dropdownOpen" :id="`vs${uid}__listbox`" :key="`vs${uid}__listbox`" class="vs__dropdown-menu" role="listbox" @mousedown.prevent="onMousedown" @mouseup="onMouseUp" tabindex="-1" v-append-to-body>
         <slot name="list-header" v-bind="scope.listHeader" />
         <li
           role="option"


### PR DESCRIPTION
Proposed fix for https://github.com/sagalbot/vue-select/issues/1303 where you have to double-tab out of a selected vue-select if the dropdown has a scrollbar in it, since the scrollbar seems to grab the focus before being removed.