### PR TITLE
Tr/option selection events

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,13 +9,29 @@ Triggered when the selected value changes. Used internally for `v-model`.
 this.$emit("input", val);
 ```
 
+## `option:selected`
+
+Triggered when an option has been selected. Receives the selected option.
+
+```js
+this.$emit("option:selected", selectedOption);
+```
+
+## `option:deselected`
+
+Triggered when an option has been deselected. Receives the deselected option.
+
+```js
+this.$emit("option:deselected", deselectedOption);
+```
+
 ## `option:created`
 
 Triggered when `taggable` is `true` and a new option has been created.
 
 ```js
 /**
- * @param newOption {Object} - created option  
+ * @param newOption {Object} - created option
  */
 this.$emit("option:created", newOption);
 ```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,17 +9,33 @@ Triggered when the selected value changes. Used internally for `v-model`.
 this.$emit("input", val);
 ```
 
+## `option:selecting` <Badge text="v3.11.0+" />
+
+Triggered after an option has been selected, <strong>before</strong> updating internal state. 
+
+```js
+this.$emit("option:selecting", selectedOption);
+```
+
 ## `option:selected` <Badge text="v3.11.0+" />
 
-Triggered when an option has been selected. Receives the selected option.
+Triggered when an option has been selected, <strong>after</strong> updating internal state. 
 
 ```js
 this.$emit("option:selected", selectedOption);
 ```
 
+## `option:deselecting` <Badge text="v3.11.0+" />
+
+Triggered when an option has been deselected, <strong>before</strong> updating internal state. 
+
+```js
+this.$emit("option:deselecting", selectedOption);
+```
+
 ## `option:deselected` <Badge text="v3.11.0+" />
 
-Triggered when an option has been deselected. Receives the deselected option.
+Triggered when an option has been deselected, <strong>after</strong> updating internal state. 
 
 ```js
 this.$emit("option:deselected", deselectedOption);

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,7 +9,7 @@ Triggered when the selected value changes. Used internally for `v-model`.
 this.$emit("input", val);
 ```
 
-## `option:selected`
+## `option:selected` <Badge text="v3.11.0+" />
 
 Triggered when an option has been selected. Receives the selected option.
 
@@ -17,7 +17,7 @@ Triggered when an option has been selected. Receives the selected option.
 this.$emit("option:selected", selectedOption);
 ```
 
-## `option:deselected`
+## `option:deselected` <Badge text="v3.11.0+" />
 
 Triggered when an option has been deselected. Receives the deselected option.
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -657,7 +657,7 @@
        * @return {void}
        */
       select(option) {
-        this.$emit('option:selected', option);
+        this.$emit('option:selecting', option);
         if (!this.isOptionSelected(option)) {
           if (this.taggable && !this.optionExists(option)) {
             this.$emit('option:created', option);
@@ -666,6 +666,7 @@
             option = this.selectedValue.concat(option)
           }
           this.updateValue(option);
+          this.$emit('option:selected', option);
         }
         this.onAfterSelect(option)
       },
@@ -676,10 +677,11 @@
        * @return {void}
        */
       deselect (option) {
-        this.$emit('option:deselected', option);
+        this.$emit('option:deselecting', option);
         this.updateValue(this.selectedValue.filter(val => {
           return !this.optionComparator(val, option);
         }));
+        this.$emit('option:deselected', option);
       },
 
       /**

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -657,6 +657,7 @@
        * @return {void}
        */
       select(option) {
+        this.$emit('option:selected', option);
         if (!this.isOptionSelected(option)) {
           if (this.taggable && !this.optionExists(option)) {
             this.$emit('option:created', option);
@@ -675,6 +676,7 @@
        * @return {void}
        */
       deselect (option) {
+        this.$emit('option:deselected', option);
         this.updateValue(this.selectedValue.filter(val => {
           return !this.optionComparator(val, option);
         }));

--- a/tests/unit/Selecting.spec.js
+++ b/tests/unit/Selecting.spec.js
@@ -220,5 +220,84 @@ describe("VS - Selecting Values", () => {
       Select.vm.select("bar");
       expect(Select.emitted("input")[0]).toEqual([["foo", "bar"]]);
     });
+
+    it("will not trigger the input event when multiple is true and selection is repeated", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { multiple: true, value: ["foo ", "bar"], options: ["foo", "bar", "baz"] }
+      });
+
+      Select.vm.select("bar");
+      expect(Select.emitted("input")).toBeFalsy();
+    });
+  });
+
+  describe("option:selected Event", () => {
+    it("will trigger the option:selected event when an option is selected", () => {
+      const Select = shallowMount(VueSelect);
+      Select.vm.select("bar");
+      expect(Select.emitted("option:selected")[0]).toEqual(["bar"]);
+    });
+
+    it("will trigger the option:selected event regardless of current value", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { value: ["foo"], options: ["foo", "bar"] }
+      });
+      Select.vm.select("foo");
+      Select.vm.select("bar");
+      expect(Select.emitted("option:selected")).toEqual([["foo"], ["bar"]]);
+    });
+
+    it("will trigger the option:selected event with current selected item when multiple is true", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { multiple: true, value: ["foo"], options: ["foo", "bar"] }
+      });
+      Select.vm.select("bar");
+      expect(Select.emitted("option:selected")[0]).toEqual(["bar"]);
+    });
+
+    it("will trigger the option:selected event regardless of current value when multiple is true", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { multiple: true, value: ["foo", "bar"], options: ["foo", "bar"] }
+      });
+      Select.vm.select("bar");
+      Select.vm.select("bar");
+      expect(Select.emitted("option:selected")).toEqual([["bar"], ["bar"]]);
+    });
+  });
+
+  describe("option:deselected Event", () => {
+    it("will trigger the option:deselected event when an option is deselected", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { value: ["foo"], options: ["foo", "bar"] }
+      });
+      Select.vm.deselect("foo");
+      expect(Select.emitted("option:deselected")[0]).toEqual(["foo"]);
+    });
+
+    it("will trigger the option:deselected event regardless of current value", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { value: ["foo"], options: ["foo", "bar"] }
+      });
+      Select.vm.deselect("foo");
+      Select.vm.deselect("bar");
+      expect(Select.emitted("option:deselected")).toEqual([["foo"], ["bar"]]);
+    });
+
+    it("will trigger the option:selected event with current selected item when multiple is true", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { multiple: true, value: ["foo"], options: ["foo", "bar"] }
+      });
+      Select.vm.deselect("bar");
+      expect(Select.emitted("option:deselected")[0]).toEqual(["bar"]);
+    });
+
+    it("will trigger the option:selected event regardless of current value when multiple is true", () => {
+      const Select = shallowMount(VueSelect, {
+        propsData: { multiple: true, value: ["foo", "bar"], options: ["foo", "bar"] }
+      });
+      Select.vm.deselect("bar");
+      Select.vm.deselect("bar");
+      expect(Select.emitted("option:deselected")).toEqual([["bar"], ["bar"]]);
+    });
   });
 });

--- a/tests/unit/Selecting.spec.js
+++ b/tests/unit/Selecting.spec.js
@@ -231,37 +231,37 @@ describe("VS - Selecting Values", () => {
     });
   });
 
-  describe("option:selected Event", () => {
-    it("will trigger the option:selected event when an option is selected", () => {
+  describe("option:selecting Event", () => {
+    it("will trigger the option:selecting event when an option is selected", () => {
       const Select = shallowMount(VueSelect);
       Select.vm.select("bar");
-      expect(Select.emitted("option:selected")[0]).toEqual(["bar"]);
+      expect(Select.emitted("option:selecting")[0]).toEqual(["bar"]);
     });
 
-    it("will trigger the option:selected event regardless of current value", () => {
+    it("will trigger the option:selecting event regardless of current value", () => {
       const Select = shallowMount(VueSelect, {
         propsData: { value: ["foo"], options: ["foo", "bar"] }
       });
       Select.vm.select("foo");
       Select.vm.select("bar");
-      expect(Select.emitted("option:selected")).toEqual([["foo"], ["bar"]]);
+      expect(Select.emitted("option:selecting")).toEqual([["foo"], ["bar"]]);
     });
 
-    it("will trigger the option:selected event with current selected item when multiple is true", () => {
+    it("will trigger the option:selecting event with current selected item when multiple is true", () => {
       const Select = shallowMount(VueSelect, {
         propsData: { multiple: true, value: ["foo"], options: ["foo", "bar"] }
       });
       Select.vm.select("bar");
-      expect(Select.emitted("option:selected")[0]).toEqual(["bar"]);
+      expect(Select.emitted("option:selecting")[0]).toEqual(["bar"]);
     });
 
-    it("will trigger the option:selected event regardless of current value when multiple is true", () => {
+    it("will trigger the option:selecting event regardless of current value when multiple is true", () => {
       const Select = shallowMount(VueSelect, {
         propsData: { multiple: true, value: ["foo", "bar"], options: ["foo", "bar"] }
       });
       Select.vm.select("bar");
       Select.vm.select("bar");
-      expect(Select.emitted("option:selected")).toEqual([["bar"], ["bar"]]);
+      expect(Select.emitted("option:selecting")).toEqual([["bar"], ["bar"]]);
     });
   });
 


### PR DESCRIPTION
Proposed change to add `option:selected` and `option:deselected` events:

These would be **unrelated to value change**. In the case of `option:deselected` this would not mean much, but for `option:selected` this means whenever an option is selected it triggers this event, even if the option is already in the value.

Related to #272, #1005 

I found that I was unable to create the behaviour I needed using vue-select without directly extending the component and overriding the `select` method. The behaviour is de-selectable options in the dropdown menu:

![Tags](https://user-images.githubusercontent.com/1634026/100938693-73d67b00-34f5-11eb-82dc-1f696784f23c.gif)
(this was unfortunately done with another select component)

These events would allow more complex behaviours to be implemented while relying on the component's default behaviour (technically, the above could be done by adding `click` listeners, but would break on keyboard navigation use)