### PR TITLE
[docs] Add search event to documentation

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -4,7 +4,7 @@ Triggered when the selected value changes. Used internally for `v-model`.
 
 ```js
 /**
- * @param val {Object|String}` - selected option.
+ * @param {Object|String} val - selected option.
  */
 this.$emit("input", val);
 ```
@@ -47,7 +47,7 @@ Triggered when `taggable` is `true` and a new option has been created.
 
 ```js
 /**
- * @param newOption {Object} - created option
+ * @param {Object} newOption - created option
  */
 this.$emit("option:created", newOption);
 ```

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -52,6 +52,17 @@ Triggered when `taggable` is `true` and a new option has been created.
 this.$emit("option:created", newOption);
 ```
 
+## `search`
+
+Triggered on search.
+
+```js
+/**
+ * @param {String} searchString - the search string
+ */
+this.$emit("search", searchString);
+```
+
 ## `search:blur`
 
 Triggered when the text input loses focus. The dropdown will close immediately before this

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -59,8 +59,14 @@ Triggered on search.
 ```js
 /**
  * @param {String} searchString - the search string
+ * @param {Function} toggleLoading - callback to toggle loading state
  */
-this.$emit("search", searchString);
+this.$emit("search", searchString, toggleLoading = (toggle = null) {
+  if (toggle == null) {
+    return (this.mutableLoading = !this.mutableLoading);
+  }
+  return (this.mutableLoading = toggle);
+});
 ```
 
 ## `search:blur`

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -54,19 +54,31 @@ this.$emit("option:created", newOption);
 
 ## `search`
 
-Triggered on search.
+Anytime the search string changes, emit the
+'search' event. The event is passed with two 
+parameters: the search string, and a function 
+that accepts a boolean parameter to toggle the 
+loading state.
+
+See the [AJAX Guide](/guide/ajax.html#loading-options-with-ajax) 
+for a complete example.
 
 ```js
 /**
  * @param {String} searchString - the search string
- * @param {Function} toggleLoading - callback to toggle loading state
+ * @param {Function} toggleLoading - function to toggle loading state, accepts true or false boolean
  */
-this.$emit("search", searchString, toggleLoading = (toggle = null) {
-  if (toggle == null) {
-    return (this.mutableLoading = !this.mutableLoading);
-  }
-  return (this.mutableLoading = toggle);
-});
+this.$emit('search', this.search, this.toggleLoading);
+```
+
+```vue
+<!-- example usage -->
+<v-select
+    @search="(search, loading) => { 
+      loading(true)
+      fetchOptions(search).then(() => loading(false))
+    }"
+/>
 ```
 
 ## `search:blur`


### PR DESCRIPTION
I noticed a `search` event that wasn't documented in the general API->Events documentation page. It is currently mentioned in the [infinite scroll](https://vue-select.org/guide/infinite-scroll.html) section.

This PR adds a section for the `search` event + corrects JSDoc in the example of two other events ([jsdoc.app lists types first, then parameter name](https://jsdoc.app/tags-param.html) - for example `@param {Object} foo` instead of `@param foo {Object}`).