### PR TITLE
Allow showing options while loading

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -328,6 +328,19 @@ label: {
 ```
 
 
+## loading
+
+Tells vue-select if component is loading, displaying the loading
+spinner and toggling off options dropdown (unless `showOptionsWhileLoading` is `true`)
+
+```js
+loading: {
+  type: Boolean,
+  default: false
+}
+```
+
+
 ## maxHeight
 
 ::: warning Deprecated in `v2.x` & Removed in `v3.0`
@@ -503,6 +516,18 @@ When true, hitting the 'tab' key will select the current select value
 selectOnTab: {
 	type: Boolean,
 	default: false
+}
+```
+
+
+## showOptionsWhileLoading
+
+When true, continues showing options even if `loading` is true
+
+```js
+loading: {
+  type: Boolean,
+  default: false
 }
 ```
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -461,6 +461,15 @@
       },
 
       /**
+       * Show options while loading.
+       * @type {Boolean}
+       */
+      showOptionsWhileLoading: {
+        type: Boolean,
+        default: false
+      },
+
+      /**
        * Sets the id of the input element.
        * @type {String}
        * @default {null}
@@ -1132,7 +1141,7 @@
        * @return {Boolean} True if open
        */
       dropdownOpen() {
-        return this.noDrop ? false : this.open && !this.mutableLoading
+        return this.noDrop ? false : this.open && (this.showOptionsWhileLoading || !this.mutableLoading)
       },
 
       /**

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -188,4 +188,38 @@ describe("Toggling Dropdown", () => {
     expect(Select.classes('vs--searching')).toBeFalsy();
   });
 
+  it("should not display the dropdown if loading is true", async () => {
+    const Select = selectWithProps({
+      loading: true,
+      options: [{ label: "one" }],
+    });
+
+    Select.vm.toggleDropdown(clickEvent(Select.vm.$refs.search));
+
+    expect(Select.vm.open).toEqual(true);
+    await Select.vm.$nextTick();
+
+    expect(Select.contains('.vs__dropdown-menu')).toBeFalsy();
+    expect(Select.contains('.vs__dropdown-option')).toBeFalsy();
+    expect(Select.contains('.vs__no-options')).toBeFalsy();
+    expect(Select.vm.stateClasses['vs--open']).toBeFalsy();
+  });
+
+  it("should display the dropdown if loading is true and showOptionsWhileLoading is true", async () => {
+    const Select = selectWithProps({
+      loading: true,
+      showOptionsWhileLoading: true,
+      options: [{ label: "one" }],
+    });
+
+    Select.vm.toggleDropdown(clickEvent(Select.vm.$refs.search));
+
+    expect(Select.vm.open).toEqual(true);
+    await Select.vm.$nextTick();
+
+    expect(Select.contains('.vs__dropdown-menu')).toBeTruthy();
+    expect(Select.contains('.vs__dropdown-option')).toBeTruthy();
+    expect(Select.contains('.vs__no-options')).toBeFalsy();
+    expect(Select.vm.stateClasses['vs--open']).toBeTruthy();
+  });
 });


### PR DESCRIPTION
This adds a prop, `showOptionsWhileLoading` which maintains option visibility while loading AJAX data.