### PR TITLE
add open and close events to the documentation

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -22,7 +22,7 @@ this.$emit("open");
 Triggered when the dropdown is closed.
 
 ```js
-this.$emilt('close');
+this.$emit("close");
 ```
 
 ## `option:selecting` <Badge text="v3.11.0+" />

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -9,6 +9,22 @@ Triggered when the selected value changes. Used internally for `v-model`.
 this.$emit("input", val);
 ```
 
+## `open`
+
+Triggered when the dropdown is open.
+
+```js
+this.$emit("open");
+```
+
+## `close`
+
+Triggered when the dropdown is closed.
+
+```js
+this.$emilt('close');
+```
+
 ## `option:selecting` <Badge text="v3.11.0+" />
 
 Triggered after an option has been selected, <strong>before</strong> updating internal state. 


### PR DESCRIPTION
I discovered these two when I was playing around the Vue dev tools. They are pretty useful for some cases.