### PR TITLE
fix: filter unique options in optionList

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -795,10 +795,7 @@
       findOptionFromReducedValue (value) {
         const predicate = option => JSON.stringify(this.reduce(option)) === JSON.stringify(value);
 
-        const matches = [
-          ...this.options,
-          ...this.pushedTags,
-        ].filter(predicate);
+        const matches = this.optionList.filter(predicate);
 
         if (matches.length === 1) {
           return matches[0];
@@ -1013,7 +1010,13 @@
        * @return {Array}
        */
       optionList () {
-        return this.options.concat(this.pushTags ? this.pushedTags : []);
+        const uniqueOptions = this.options.concat(this.pushTags ? this.pushedTags : []).reduce((acc, option)=>{
+          const idx = acc.findIndex((item) => this.getOptionKey(item) === this.getOptionKey(option));
+          if (idx === -1) acc.push(option);
+          return acc;
+        }, []);
+
+        return uniqueOptions;
       },
 
       /**


### PR DESCRIPTION
When `$emit('option:created')` reactivly updates `options`
`pushedTags` and `options` are identical

Therefore, when triggering
`findOptionFromReducedValue()`
original `option` (object) will never be returned, instead will only return `value`,
because the match found will always be greater than 1.