### PR TITLE
Fix `vs__selected` position while loading with empty search value

### DIFF
--- a/src/scss/modules/_selected.scss
+++ b/src/scss/modules/_selected.scss
@@ -31,7 +31,8 @@
     background-color: transparent;
     border-color: transparent;
   }
-  &.vs--open .vs__selected {
+  &.vs--open .vs__selected,
+  &.vs--loading .vs__selected {
     position: absolute;
     opacity: .4;
   }


### PR DESCRIPTION
The states *open* and *loading* should behave similarly