### PR TITLE
The docs are missing the @search event.

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -69,3 +69,21 @@ event is triggered.
 ```js
 this.$emit("search:focus");
 ```
+
+## `search`
+
+Triggered when the search text changes.
+
+```js
+/**
+ * Anytime the search string changes, emit the
+ * 'search' event. The event is passed with two
+ * parameters: the search string, and a function
+ * that accepts a boolean parameter to toggle the
+ * loading state.
+ *
+ * @emits search
+ */
+this.$emit('search', newSearchString, toggleLoading);
+```
+


### PR DESCRIPTION
The docs are missing the @search event.
Usually the devs go straight to the API specification without reading the full documentation. It's good to include the @search event also in the events API specification