### PR TITLE
Change mouse down event to click event

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -64,7 +64,7 @@
           :class="{ 'vs__dropdown-option--selected': isOptionSelected(option), 'vs__dropdown-option--highlight': index === typeAheadPointer, 'vs__dropdown-option--disabled': !selectable(option) }"
           :aria-selected="index === typeAheadPointer ? true : null"
           @mouseover="selectable(option) ? typeAheadPointer = index : null"
-          @mousedown.prevent.stop="selectable(option) ? select(option) : null"
+          @click.prevent.stop="selectable(option) ? select(option) : null"
         >
           <slot name="option" v-bind="normalizeOptionForSlot(option)">
             {{ getOptionLabel(option) }}


### PR DESCRIPTION
The #1272 problem was solved by changing the mouse down event to a click event.
If there is a reason why it should be a mouse down event instead of a click event, please let me know.