### PR TITLE
feat: add dropdownShouldOpen prop

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -187,6 +187,21 @@ disabled: {
 },
 ```
 
+## dropdownShouldOpen <Badge text="v3.12.0+" />
+
+Determines whether the dropdown should open. Used 
+for overriding the default dropdown behaviour. Receives
+the vue-select instance as the single argument to the function.
+
+```js
+dropdownShouldOpen: {
+    type: Function,
+    default({noDrop, open, mutableLoading}) {
+      return noDrop ? false : open && !mutableLoading;
+    }
+}
+```
+
 
 ## filter
 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -565,6 +565,20 @@
           dropdownList.style.left = left;
           dropdownList.style.width = width;
         }
+      },
+
+      /**
+       * Determines whether the dropdown should be open.
+       * Receives the component instance as the only argument.
+       *
+       * @since v3.12.0
+       * @return boolean
+       */
+      dropdownShouldOpen: {
+        type: Function,
+        default({noDrop, open, mutableLoading}) {
+          return noDrop ? false : open && !mutableLoading;
+        }
       }
     },
 
@@ -1132,7 +1146,7 @@
        * @return {Boolean} True if open
        */
       dropdownOpen() {
-        return this.noDrop ? false : this.open && !this.mutableLoading
+        return this.dropdownShouldOpen(this);
       },
 
       /**

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -188,4 +188,14 @@ describe("Toggling Dropdown", () => {
     expect(Select.classes('vs--searching')).toBeFalsy();
   });
 
+  it("can be opened with dropdownShouldOpen", () => {
+    const Select = selectWithProps({
+      noDrop: true,
+      dropdownShouldOpen: () => true,
+      options: ['one']
+    });
+
+    expect(Select.classes('vs--open')).toBeTruthy();
+    expect(Select.find('.vs__dropdown-menu li')).toBeTruthy();
+  })
 });


### PR DESCRIPTION
Adds a new props to determines whether the dropdown should open. Used for overriding the default dropdown behaviour. Receives the vue-select instance as the single argument to the function.