### PR TITLE
Set !default for $vs-controls-deselect-text-shadow

### DIFF
--- a/src/scss/global/_variables.scss
+++ b/src/scss/global/_variables.scss
@@ -28,7 +28,7 @@ $vs-border-color: map_get($vs-colors, 'lightest') !default;
 //  Component Controls: Clear, Open Indicator
 $vs-controls-color: map_get($vs-colors, 'light') !default;
 $vs-controls-size: 1 !default;
-$vs-controls-deselect-text-shadow: 0 1px 0 #fff;
+$vs-controls-deselect-text-shadow: 0 1px 0 #fff !default;
 
 //  Selected
 $vs-selected-bg: #f0f0f0 !default;


### PR DESCRIPTION
- added missing `!default` for $vs-controls-deselect-text-shadow, which was the only one not having it
- `!default` is necessary in order to be able override the variable

Resolves #1467