### PR TITLE
fix(Paginated): fix bugs in Pagination use case example in docs

### DIFF
--- a/docs/.vuepress/components/Paginated.vue
+++ b/docs/.vuepress/components/Paginated.vue
@@ -1,12 +1,8 @@
 <template>
-  <v-select
-    :options="paginated"
-    :filterable="false"
-    @search="(query) => (search = query)"
-  >
+  <v-select :options="paginated" :filterable="false" @search="onSearch">
     <li slot="list-footer" class="pagination">
-      <button :disabled="!hasPrevPage" @click="offset -= 10">Prev</button>
-      <button :disabled="!hasNextPage" @click="offset += 10">Next</button>
+      <button :disabled="!hasPrevPage" @click="offset -= limit">Prev</button>
+      <button :disabled="!hasNextPage" @click="offset += limit">Next</button>
     </li>
   </v-select>
 </template>
@@ -22,22 +18,30 @@ export default {
   }),
   computed: {
     filtered() {
-      return this.countries.filter((country) => country.includes(this.search))
+      return this.countries.filter((country) =>
+        country.toLowerCase().includes(this.search.toLowerCase())
+      )
     },
     paginated() {
       return this.filtered.slice(this.offset, this.limit + this.offset)
     },
     hasNextPage() {
-      const nextOffset = this.offset + 10
+      const nextOffset = this.offset + this.limit
       return Boolean(
         this.filtered.slice(nextOffset, this.limit + nextOffset).length
       )
     },
     hasPrevPage() {
-      const prevOffset = this.offset - 10
+      const prevOffset = this.offset - this.limit
       return Boolean(
         this.filtered.slice(prevOffset, this.limit + prevOffset).length
       )
+    },
+  },
+  methods: {
+    onSearch(query) {
+      this.search = query
+      this.offset = 0
     },
   },
 }


### PR DESCRIPTION
Hi! Thanks for the great library. I had some ideas to improve some possibly buggy behavior in the Pagination use case example in the docs.

Firstly, there is arguably a bug when clicking through result pages and typing to search. Steps to reproduce:

- Visit https://vue-select.org/guide/pagination.html
- Click into the live select component to expand the dropdown
- Click "next" two times
- Type "Bahr"
- Notice there are no results

If you took the same steps minus the clicking of "next", you would see the result "Bahrain". The buggy scenario occurs because after clicking "next" twice, you're on the third page of results, yet there is only one result and thus one page after searching for "Bahr", so you end up in a limbo state in an empty third page of results. I would guess that this isn't desired and I've come up with a simple fix in this PR by simply resetting `offset` to `0` whenever the search query is updated.

I've also changed two other things that are not necessarily bugs but that I think could be improved:

- I replaced instances of a "magic number" `10` with the `limit` data prop; this way when a user updates `limit` to something other than `10`, the "prev" and "next" buttons step through the right number of results.
- I converted query and country name strings to lower case before filtering the list so that the user doesn't have to match the exact case of the country names. I'm not sure if the existing case-sensitivity was intentional but this may be a nicer user experience?

Thanks for your time!