### PR TITLE
Always set `cursor` CSS property, not just on hover

### DIFF
--- a/src/scss/modules/_search-input.scss
+++ b/src/scss/modules/_search-input.scss
@@ -50,7 +50,7 @@ $font-size: 1em;
   .vs__search {
     opacity: 1;
   }
-  &:not(.vs--disabled) .vs__search:hover {
+  &:not(.vs--disabled) .vs__search {
     cursor: pointer;
   }
 }


### PR DESCRIPTION
There is no benefit in only applying it on hover.

For my use case (backdrop opens when select is focused, dropdown is attached to body), it sometimes causes flickering when hovering over `.vs__search` while opening the dropdown.