### PR TITLE
Fix toggleDropdown bug

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1101,7 +1101,7 @@ export default {
       //  don't react to click on deselect/clear buttons,
       //  they dropdown state will be set in their click handlers
       const ignoredButtons = [
-        ...(this.$refs['deselectButtons'] || []),
+        ...([this.$refs['deselectButtons']] || []),
         ...([this.$refs['clearButton']] || []),
       ]
 


### PR DESCRIPTION
Hi, when using multiple mode with beta version there is a bug when try to select after first select.

![image](https://user-images.githubusercontent.com/8780913/142838663-2709d46c-2c63-43af-b34d-89a9ef1f62f3.png)

This bug comes from toggleDropdown function in select.vue component.

### Here my config for dev.vue to reproduce bug:
<img width="226" alt="Screen Shot 2021-11-22 at 12 40 34" src="https://user-images.githubusercontent.com/8780913/142839113-ecc7f926-ecf9-471b-a860-bcd28cd35ec9.png">

Type of this.$refs['deselectButtons'] is object after first selection in multiple mode and tries to spread on object.

```
const ignoredButtons = [
        ...(this.$refs['deselectButtons'] || []),
        ...([this.$refs['clearButton']] || []),
]
```

Actually, on the bottom line for clearButton ref its wrapped in an array. I applied same for deselectButtons.

This commit fixes the bug.