### PR TITLE
fix: wait for loading before createOption

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -873,7 +873,7 @@ export default {
       let options = this.search.length
         ? this.filter(optionList, this.search, this)
         : optionList
-      if (this.taggable && this.search.length) {
+      if (this.taggable && this.search.length && !this.mutableLoading) {
         const createdOption = this.createOption(this.search)
         if (!this.optionExists(createdOption)) {
           options.unshift(createdOption)


### PR DESCRIPTION
When using `taggable`, `multiple` and `createOption`, a new option should be created after loading is done.
Fixes scenario when user types an existing tag and press "enter" before an async search has been processed.