### PR TITLE
docs: removing duplicate `search` doc

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -114,21 +114,3 @@ event is triggered.
 ```js
 this.$emit("search:focus");
 ```
-
-## `search`
-
-Triggered when the search text changes.
-
-```js
-/**
- * Anytime the search string changes, emit the
- * 'search' event. The event is passed with two
- * parameters: the search string, and a function
- * that accepts a boolean parameter to toggle the
- * loading state.
- *
- * @emits search
- */
-this.$emit('search', newSearchString, toggleLoading);
-```
-


### PR DESCRIPTION
this is already covered line 71