### PR TITLE
feat: add input-background css variable

### DIFF
--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -6,6 +6,7 @@
 
     /* Search Input */
     --vs-search-input-color: inherit;
+    --vs-input-background: rgb(255, 255, 255);
     --vs-search-input-placeholder-color: inherit;
 
     /* Font */
@@ -20,7 +21,7 @@
 
     /* Borders */
     --vs-border-color: var(--vs-colors--lightest);
-    --vs-border-width: 1px;
+    --vs-border-width: 0;
     --vs-border-style: solid;
     --vs-border-radius: 4px;
 

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -21,7 +21,7 @@
 
     /* Borders */
     --vs-border-color: var(--vs-colors--lightest);
-    --vs-border-width: 0;
+    --vs-border-width: 1px;
     --vs-border-style: solid;
     --vs-border-radius: 4px;
 

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -6,7 +6,7 @@
 
     /* Search Input */
     --vs-search-input-color: inherit;
-    --vs-input-background: rgb(255, 255, 255);
+    --vs-search-input-bg: rgb(255, 255, 255);
     --vs-search-input-placeholder-color: inherit;
 
     /* Font */

--- a/src/css/modules/dropdown-toggle.css
+++ b/src/css/modules/dropdown-toggle.css
@@ -14,7 +14,7 @@
     appearance: none;
     display: flex;
     padding: 0 0 4px 0;
-    background: none;
+    background: var(--vs-input-background);
     border: var(--vs-border-width) var(--vs-border-style) var(--vs-border-color);
     border-radius: var(--vs-border-radius);
     white-space: normal;

--- a/src/css/modules/dropdown-toggle.css
+++ b/src/css/modules/dropdown-toggle.css
@@ -14,7 +14,7 @@
     appearance: none;
     display: flex;
     padding: 0 0 4px 0;
-    background: var(--vs-input-background);
+    background: var(--vs-search-input-bg);
     border: var(--vs-border-width) var(--vs-border-style) var(--vs-border-color);
     border-radius: var(--vs-border-radius);
     white-space: normal;


### PR DESCRIPTION
The goal for this PR is to be able to change the input background color.

Material Design has an option: `filled` which changes background color from `white` to `light` one, 

currently, the background is hardcoded. 
This PR adds new variable: `--vs-input-background` to override default background color

Example of `filled` applied by customizing `--vs-input-background`:

![image](https://user-images.githubusercontent.com/42810389/179390630-321a1cdd-669c-418b-b007-e3082ce408da.png)
