### PR TITLE
Rtl improvements

### DIFF
--- a/src/css/global/states.css
+++ b/src/css/global/states.css
@@ -40,7 +40,7 @@
     }
 
     .vs__clear {
-        margin-left: 6px;
+        margin-left: var(--vs-controls--clear-margin);
         margin-right: 0;
     }
 

--- a/src/css/global/states.css
+++ b/src/css/global/states.css
@@ -35,9 +35,7 @@
  */
 
 .v-select[dir='rtl'] {
-    .vs__actions {
-        padding: 0 3px 0 6px;
-    }
+    --vs-actions-padding: 4px 3px 0 6px;
 
     .vs__clear {
         margin-left: var(--vs-controls--clear-margin);

--- a/src/css/global/states.css
+++ b/src/css/global/states.css
@@ -46,7 +46,7 @@
 
     .vs__deselect {
         margin-left: 0;
-        margin-right: 2px;
+        margin-right: var(--vs-controls--deselect-margin);
     }
 
     .vs__dropdown-menu {

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -33,6 +33,7 @@
     --vs-controls-size: 1;
     --vs-controls--deselect-text-shadow: 0 1px 0 #fff;
     --vs-controls--deselect-margin: 4px;
+    --vs-controls--clear-margin: 8px;
 
     /* Selected */
     --vs-selected-bg: #f0f0f0;

--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -32,6 +32,7 @@
     --vs-controls-color: var(--vs-colors--light);
     --vs-controls-size: 1;
     --vs-controls--deselect-text-shadow: 0 1px 0 #fff;
+    --vs-controls--deselect-margin: 4px;
 
     /* Selected */
     --vs-selected-bg: #f0f0f0;

--- a/src/css/modules/clear.css
+++ b/src/css/modules/clear.css
@@ -6,5 +6,5 @@
     border: 0;
     background-color: transparent;
     cursor: pointer;
-    margin-right: 8px;
+    margin-right: var(--vs-controls--clear-margin);
 }

--- a/src/css/modules/selected.css
+++ b/src/css/modules/selected.css
@@ -16,7 +16,7 @@
 .vs__deselect {
     display: inline-flex;
     appearance: none;
-    margin-left: 4px;
+    margin-left: var(--vs-controls--deselect-margin);
     padding: 0;
     border: 0;
     cursor: pointer;


### PR DESCRIPTION
### CHANGES

#### fix vs_actions alignment (due to wrong padding in RTL mode):
- change ~~`padding: 0 3px 0 6px`~~ => `padding: 4px 3px 0 6px` in RTL mode
- override `--vs-actions-padding` variable in RTL mode to be  `4px 3px 0 6px`

#### unify vs_clear margin between RTL - LTR modes
- add new CSS variable `--vs-controls--clear-margin`
- use it in both RTL - LTR modes

#### unify vs_deselect margin between RTL - LTR modes
- add new CSS variable `--vs-controls--deselect-margin`
- use it in both RTL - LTR modes
