### PR TITLE
fix: force to run in vue3 mode when using @vue/compat

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -153,6 +153,10 @@ export default {
   directives: { appendToBody },
 
   mixins: [pointerScroll, typeAheadPointer, ajax],
+  
+  compatConfig: {
+    MODE: 3,
+  },
 
   emits: [
     'open',


### PR DESCRIPTION
When users run `vue-select` in `@vue/compat` build with default to vue 2, some events will not work (such as `update:modelValue` [as reported here](https://github.com/sagalbot/vue-select/issues/1597#issuecomment-1204076841).

Fix comes from official docs: https://v3-migration.vuejs.org/migration-build.html#per-component-config

Should not impact environment that are not running the compatibility build.