### PR TITLE
fix(#1679): css file not being exported by package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
         ".": {
             "import": "./dist/vue-select.es.js",
             "require": "./dist/vue-select.umd.js"
+        },
+        "./dist/vue-select.css": {
+            "import": "./dist/vue-select.css",
+            "require": "./dist/vue-select.css"
         }
     },
     "private": false,


### PR DESCRIPTION
This PR fixes issue with #1678 by adding css exports declaration in `package.json` 