### PR TITLE
fix: invalid CSS - selectors attempting to be nested

### DIFF
--- a/src/css/global/states.css
+++ b/src/css/global/states.css
@@ -15,15 +15,13 @@
     --vs-disabled-cursor: var(--vs-state-disabled-cursor);
 }
 
-.vs--disabled {
-    .vs__dropdown-toggle,
-    .vs__clear,
-    .vs__search,
-    .vs__selected,
-    .vs__open-indicator {
-        cursor: var(--vs-disabled-cursor);
-        background-color: var(--vs-disabled-bg);
-    }
+.vs--disabled .vs__dropdown-toggle, 
+.vs--disabled .vs__clear,
+.vs--disabled .vs__search,
+.vs--disabled .vs__selected,
+.vs--disabled .vs__open-indicator {
+    cursor: var(--vs-disabled-cursor);
+    background-color: var(--vs-disabled-bg);
 }
 
 /*
@@ -34,22 +32,17 @@
  *  rearranging the child elements visually.
  */
 
-.v-select[dir='rtl'] {
-    .vs__actions {
-        padding: 0 3px 0 6px;
-    }
-
-    .vs__clear {
-        margin-left: 6px;
-        margin-right: 0;
-    }
-
-    .vs__deselect {
-        margin-left: 0;
-        margin-right: 2px;
-    }
-
-    .vs__dropdown-menu {
-        text-align: right;
-    }
+.v-select[dir='rtl'] .vs__actions {
+    padding: 0 3px 0 6px;
+}
+.v-select[dir='rtl'] .vs__clear {
+    margin-left: 6px;
+    margin-right: 0;
+}
+.v-select[dir='rtl'] .vs__deselect {
+    margin-left: 0;
+    margin-right: 2px;
+}
+.v-select[dir='rtl'] .vs__dropdown-menu {
+    text-align: right;
 }

--- a/src/css/modules/search-input.css
+++ b/src/css/modules/search-input.css
@@ -44,18 +44,14 @@
  */
 
 /* Unsearchable */
-.vs--unsearchable {
-    .vs__search {
-        opacity: 1;
-    }
-    &:not(.vs--disabled) .vs__search {
-        cursor: pointer;
-    }
+.vs--unsearchable .vs__search {
+    opacity: 1;
+}
+.vs--unsearchable:not(.vs--disabled) .vs__search {
+    cursor: pointer;
 }
 
 /* Single, when searching but not loading or open */
-.vs--single.vs--searching:not(.vs--open):not(.vs--loading) {
-    .vs__search {
-        opacity: 0.2;
-    }
+.vs--single.vs--searching:not(.vs--open):not(.vs--loading) .vs__search {
+    opacity: 0.2;
 }

--- a/src/css/modules/selected.css
+++ b/src/css/modules/selected.css
@@ -27,17 +27,15 @@
 
 /* States */
 
-.vs--single {
-    .vs__selected {
-        background-color: transparent;
-        border-color: transparent;
-    }
-    &.vs--open .vs__selected,
-    &.vs--loading .vs__selected {
-        position: absolute;
-        opacity: 0.4;
-    }
-    &.vs--searching .vs__selected {
-        display: none;
-    }
+.vs--single .vs__selected {
+    background-color: transparent;
+    border-color: transparent;
+}
+.vs--single.vs--open .vs__selected,
+.vs--single.vs--loading .vs__selected {
+    position: absolute;
+    opacity: 0.4;
+}
+.vs--single.vs--searching .vs__selected {
+    display: none;
 }


### PR DESCRIPTION
Some styles are nested inside selectors (but the files are CSS, not SCSS), so the CSS doesn't load correctly. I've separated the nesting out into their own selectors, so the CSS would run.

Example with `.vs--single`
<img width="425" alt="vs--single" src="https://user-images.githubusercontent.com/15649024/192273787-832af656-0023-4748-82dc-beeb88d79bcb.png">
