### PR TITLE
feat: adding `required` property to input attributes

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -665,6 +665,15 @@ export default {
       type: [String, Number],
       default: () => uniqueId(),
     },
+
+    /**
+     * Equivalent to the `required` attribute on a `<select>` input.
+     * @type {Boolean}
+     */
+    required: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data() {
@@ -763,6 +772,7 @@ export default {
                   'aria-activedescendant': `vs${this.uid}__option-${this.typeAheadPointer}`,
                 }
               : {}),
+            required: this.required && this.isValueEmpty,
           },
           events: {
             compositionstart: () => (this.isComposing = true),


### PR DESCRIPTION
Added the `required` property to delegate to the component itself the responsibility of understanding how to define this characteristic. This makes `required` easier to use, making it similar to the `select` tag in HTML.

![image](https://user-images.githubusercontent.com/68401286/193593680-3e6e3e9e-b178-4f0c-9a44-00d1533e6c50.png)
