### PR TITLE
fix: css exports for webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         },
         "./dist/vue-select.css": {
             "import": "./dist/vue-select.css",
-            "require": "./dist/vue-select.css"
+            "require": "./dist/vue-select.css",
+             "style": "./dist/vue-select.css"
         }
     },
     "private": false,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "./dist/vue-select.css": {
             "import": "./dist/vue-select.css",
             "require": "./dist/vue-select.css",
-             "style": "./dist/vue-select.css"
+            "style": "./dist/vue-select.css"
         }
     },
     "private": false,


### PR DESCRIPTION
The `style` property is required by webpack

https://webpack.js.org/guides/package-exports/#:~:text=Request%20is%20issued%20from%20a%20stylesheet%20reference.

Ref https://github.com/sagalbot/vue-select/issues/1678#issuecomment-1276165767

cc @MaxKorlaar