### PR TITLE
fix: Keep focus on input after select to improve accessibility

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -960,7 +960,7 @@ export default {
     },
 
     search(search) {
-      if (!this.open && search) {
+      if (search.length) {
         this.open = true
       }
     },

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -958,6 +958,12 @@ export default {
     open(isOpen) {
       this.$emit(isOpen ? 'open' : 'close')
     },
+
+    search(search) {
+      if (!this.open && search) {
+        this.open = true
+      }
+    },
   },
 
   created() {
@@ -1350,22 +1356,6 @@ export default {
 
       if (typeof handlers[e.keyCode] === 'function') {
         return handlers[e.keyCode](e)
-      }
-
-      const isModifierKeyActive = (e) => {
-        // Allow `shiftKey` for capitalized characters
-        const modifierProperties = ['ctrlKey', 'altKey', 'metaKey']
-        return modifierProperties.some((property) => e[property])
-      }
-
-      const alphanumericCharRegex = /^[a-z0-9]{1}$/i
-
-      if (
-        !this.open &&
-        !isModifierKeyActive(e) &&
-        alphanumericCharRegex.test(e.key)
-      ) {
-        this.open = true
       }
     },
   },

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1239,7 +1239,7 @@ export default {
      */
     onEscape() {
       if (!this.search.length) {
-        this.searchEl.blur()
+        this.open = false
       } else {
         this.search = ''
       }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -571,7 +571,12 @@ export default {
      */
     selectOnKeyCodes: {
       type: Array,
-      default: () => [13],
+      default: () => [
+        // enter
+        13,
+        // space
+        32,
+      ],
     },
 
     /**

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1035,7 +1035,6 @@ export default {
     onAfterSelect(option) {
       if (this.closeOnSelect) {
         this.open = !this.open
-        this.searchEl.blur()
       }
 
       if (this.clearSearchOnSelect) {

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1320,11 +1320,19 @@ export default {
         //  up.prevent
         38: (e) => {
           e.preventDefault()
+          if (!this.open) {
+            this.open = true
+            return
+          }
           return this.typeAheadUp()
         },
         //  down.prevent
         40: (e) => {
           e.preventDefault()
+          if (!this.open) {
+            this.open = true
+            return
+          }
           return this.typeAheadDown()
         },
       }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1351,6 +1351,22 @@ export default {
       if (typeof handlers[e.keyCode] === 'function') {
         return handlers[e.keyCode](e)
       }
+
+      const isModifierKeyActive = (e) => {
+        // Allow `shiftKey` for capitalized characters
+        const modifierProperties = ['ctrlKey', 'altKey', 'metaKey']
+        return modifierProperties.some((property) => e[property])
+      }
+
+      const alphanumericCharRegex = /^[a-z0-9]{1}$/i
+
+      if (
+        !this.open &&
+        !isModifierKeyActive(e) &&
+        alphanumericCharRegex.test(e.key)
+      ) {
+        this.open = true
+      }
     },
   },
 }

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1302,7 +1302,7 @@ export default {
 
     /**
      * Search <input> KeyBoardEvent handler.
-     * @param e {KeyboardEvent}
+     * @param {KeyboardEvent} e
      * @return {Function}
      */
     onSearchKeyDown(e) {

--- a/src/mixins/typeAheadPointer.js
+++ b/src/mixins/typeAheadPointer.js
@@ -76,12 +76,16 @@ export default {
      * Moves the pointer to the last selected option.
      */
     typeAheadToLastSelected() {
-      this.typeAheadPointer =
+      const indexOfLastSelected =
         this.selectedValue.length !== 0
           ? this.filteredOptions.indexOf(
               this.selectedValue[this.selectedValue.length - 1]
             )
           : -1
+
+      if (indexOfLastSelected !== -1) {
+        this.typeAheadPointer = indexOfLastSelected
+      }
     },
   },
 }

--- a/tests/unit/Dropdown.spec.js
+++ b/tests/unit/Dropdown.spec.js
@@ -120,12 +120,11 @@ describe('Toggling Dropdown', () => {
 
   it('will close the dropdown on escape, if search is empty', () => {
     const Select = selectWithProps()
-    const spy = jest.spyOn(Select.vm.$refs.search, 'blur')
 
     Select.vm.open = true
     Select.vm.onEscape()
 
-    expect(spy).toHaveBeenCalled()
+    expect(Select.vm.open).toEqual(false)
   })
 
   it('should remove existing search text on escape keydown', () => {

--- a/tests/unit/Filtering.spec.js
+++ b/tests/unit/Filtering.spec.js
@@ -83,4 +83,26 @@ describe('Filtering Options', () => {
     Select.vm.search = '1'
     expect(Select.vm.filteredOptions).toEqual([1, 10])
   })
+
+  it('should open dropdown on alphabetic input', async () => {
+    const Select = shallowMount(VueSelect)
+
+    const input = Select.find('.vs__search')
+    input.element.value = 'a'
+    input.trigger('input')
+    await Select.vm.$nextTick()
+
+    expect(Select.vm.open).toEqual(true)
+  })
+
+  it('should open dropdown on numeric input', async () => {
+    const Select = shallowMount(VueSelect)
+
+    const input = Select.find('.vs__search')
+    input.element.value = 1
+    input.trigger('input')
+    await Select.vm.$nextTick()
+
+    expect(Select.vm.open).toEqual(true)
+  })
 })

--- a/tests/unit/Keydown.spec.js
+++ b/tests/unit/Keydown.spec.js
@@ -40,22 +40,6 @@ describe('Custom Keydown Handlers', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
-  it('should open dropdown on alphabetic keydown', () => {
-    const Select = mountDefault()
-
-    Select.findComponent({ ref: 'search' }).trigger('keydown', { key: 'a' })
-
-    expect(Select.vm.open).toEqual(true)
-  })
-
-  it('should open dropdown on numeric keydown', () => {
-    const Select = mountDefault()
-
-    Select.findComponent({ ref: 'search' }).trigger('keydown', { key: 1 })
-
-    expect(Select.vm.open).toEqual(true)
-  })
-
   describe('CompositionEvent support', () => {
     it('will not select a value with enter if the user is composing', () => {
       const Select = mountDefault()

--- a/tests/unit/Keydown.spec.js
+++ b/tests/unit/Keydown.spec.js
@@ -40,6 +40,22 @@ describe('Custom Keydown Handlers', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
+  it('should open dropdown on alphabetic keydown', () => {
+    const Select = mountDefault()
+
+    Select.findComponent({ ref: 'search' }).trigger('keydown', { key: 'a' })
+
+    expect(Select.vm.open).toEqual(true)
+  })
+
+  it('should open dropdown on numeric keydown', () => {
+    const Select = mountDefault()
+
+    Select.findComponent({ ref: 'search' }).trigger('keydown', { key: 1 })
+
+    expect(Select.vm.open).toEqual(true)
+  })
+
   describe('CompositionEvent support', () => {
     it('will not select a value with enter if the user is composing', () => {
       const Select = mountDefault()

--- a/tests/unit/Selectable.spec.js
+++ b/tests/unit/Selectable.spec.js
@@ -37,6 +37,7 @@ describe('Selectable prop', () => {
       selectable: (option) => option !== 'two',
     })
 
+    Select.vm.open = true
     Select.vm.typeAheadPointer = 1
 
     Select.findComponent({ ref: 'search' }).trigger('keydown.down')
@@ -50,6 +51,7 @@ describe('Selectable prop', () => {
       selectable: (option) => option !== 'two',
     })
 
+    Select.vm.open = true
     Select.vm.typeAheadPointer = 2
 
     Select.findComponent({ ref: 'search' }).trigger('keydown.up')

--- a/tests/unit/TypeAhead.spec.js
+++ b/tests/unit/TypeAhead.spec.js
@@ -20,6 +20,7 @@ describe('Moving the Typeahead Pointer', () => {
   it('should move the pointer visually up the list on up arrow keyUp', () => {
     const Select = mountDefault()
 
+    Select.vm.open = true
     Select.vm.typeAheadPointer = 1
 
     Select.findComponent({ ref: 'search' }).trigger('keydown.up')
@@ -30,6 +31,7 @@ describe('Moving the Typeahead Pointer', () => {
   it('should move the pointer visually down the list on down arrow keyUp', () => {
     const Select = mountDefault()
 
+    Select.vm.open = true
     Select.vm.typeAheadPointer = 1
 
     Select.findComponent({ ref: 'search' }).trigger('keydown.down')
@@ -77,4 +79,24 @@ describe('Moving the Typeahead Pointer', () => {
 
     expect(Select.vm.typeAheadPointer).toEqual(2)
   })
+})
+
+it('should not move the pointer visually up the list on up arrow keyUp when dropdown is not open', () => {
+  const Select = mountDefault()
+
+  Select.vm.typeAheadPointer = 1
+
+  Select.findComponent({ ref: 'search' }).trigger('keydown.up')
+
+  expect(Select.vm.typeAheadPointer).toEqual(1)
+})
+
+it('should not move the pointer visually down the list on down arrow keyUp when dropdown is not open', () => {
+  const Select = mountDefault()
+
+  Select.vm.typeAheadPointer = 1
+
+  Select.findComponent({ ref: 'search' }).trigger('keydown.down')
+
+  expect(Select.vm.typeAheadPointer).toEqual(1)
 })


### PR DESCRIPTION
Keep focus on the input after option selection and when hitting the Escape key to comply with W3C accessibility guidelines as demonstrated and described in:

- [Single-select example](https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html)
- [Multi-select example](https://www.telerik.com/kendo-angular-ui/components/dropdowns/multiselect/accessibility/)