### PR TITLE
fix() use toRaw to compare initial raw object instead of proxy

### DIFF
--- a/src/mixins/typeAheadPointer.js
+++ b/src/mixins/typeAheadPointer.js
@@ -1,3 +1,5 @@
+import { toRaw } from 'vue'
+
 export default {
   data() {
     return {
@@ -78,8 +80,10 @@ export default {
     typeAheadToLastSelected() {
       this.typeAheadPointer =
         this.selectedValue.length !== 0
-          ? this.filteredOptions.indexOf(
-              this.selectedValue[this.selectedValue.length - 1]
+          ? this.filteredOptions.findIndex(
+              (option) =>
+                toRaw(option) ===
+                toRaw(this.selectedValue[this.selectedValue.length - 1])
             )
           : -1
     },


### PR DESCRIPTION
When using the composition API, the options may or may not be wrapped in proxy for each object.
I was having a weird issue where the autoscroll feature was not working when the drop-down was opened. The selected value was a proxy, but not the items inside filteredOptions.

This fix uses the `toRaw` function to compare the raw object and not the Vue proxy object.