### PR TITLE
fix: Explicitly set file extension of module js entrypoint to `.mjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
         "dist"
     ],
     "main": "./dist/vue-select.umd.js",
-    "module": "./dist/vue-select.es.js",
+    "module": "./dist/vue-select.es.mjs",
     "exports": {
         ".": {
-            "import": "./dist/vue-select.es.js",
+            "import": "./dist/vue-select.es.mjs",
             "require": "./dist/vue-select.umd.js"
         },
         "./dist/vue-select.css": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         lib: {
             entry: resolve(__dirname, 'src/index.js'),
             name: 'vue-select',
-            fileName: (format) => `vue-select.${format}.js`,
+            fileName: (format) => `vue-select.${format}.${format === 'es' ? 'mjs' : 'js'}`,
         },
         rollupOptions: {
             external: ['vue'],


### PR DESCRIPTION
The package has no `type` set, so node will handle it as `CommonJS` and will interpret every `.js` file (even if imported from this package) as CommonJS. To prevent this, ESM files have to be explicitly named with the `.mjs` file extension.