### PR TITLE
Fix(1030): adds a customizable property for aria-label

### DIFF
--- a/docs/api/props.md
+++ b/docs/api/props.md
@@ -1,3 +1,16 @@
+## ariaLabel
+
+This value will be bound to the [aria-label
+HTML attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+for the search input. Defaults to `Search for option`.
+
+```js
+ariaLabel: {
+    type: String,
+    default: 'Search for option'
+},
+```
+
 ## appendToBody <Badge text="v3.7.0+" />
 
 Append the dropdown element to the end of the body

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -12,7 +12,7 @@
       role="combobox"
       :aria-expanded="dropdownOpen.toString()"
       :aria-owns="`vs${uid}__listbox`"
-      aria-label="Search for option"
+      :aria-label="ariaLabel"
       @mousedown="toggleDropdown($event)"
     >
       <div ref="selectedOptions" class="vs__selected-options">
@@ -243,6 +243,15 @@ export default {
     placeholder: {
       type: String,
       default: '',
+    },
+
+    /**
+     * Sets the value of the 'aria-label' for the search `<input>`.
+     * @type {String}
+     */
+    ariaLabel: {
+      type: String,
+      default: 'Search for option',
     },
 
     /**


### PR DESCRIPTION
The aria-label for the search input is currently hard-coded to "Search for option".  This causes problems for screen reader users and fails WCAG 2.1 criteria [2.5.3](https://www.w3.org/TR/WCAG21/#label-in-name) and [3.3.1](https://www.w3.org/TR/WCAG21/#labels-or-instructions).

This PR adds a new property 'ariaLabel' that can be used to change the value of aria-label for the search input.  This fixes (or at least partially fixes) the following issues:

- #1030 
- #1331 
- #1420 