### PR TITLE
Update _dropdown-toggle.scss

### DIFF
--- a/src/scss/modules/_dropdown-toggle.scss
+++ b/src/scss/modules/_dropdown-toggle.scss
@@ -29,7 +29,6 @@ $border-radius: $vs-border-radius;
     display: flex;
     flex-basis: 100%;
     flex-grow: 1;
-    flex-wrap: wrap;
     padding: 0 2px;
     position: relative;
 }


### PR DESCRIPTION
Flex wrap makes problem on multiline select item.

Default view:
![Wrap](https://drm-team.fra1.digitaloceanspaces.com/tmp/share/wrap.png)

After removing the wrap property:
![No-wrap](https://drm-team.fra1.digitaloceanspaces.com/tmp/share/no-wrap.png)