### PR TITLE
fix(1213): Skip selecting on tab if component is not open

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -394,7 +394,7 @@ export default {
     onTab: {
       type: Function,
       default: function () {
-        if (this.selectOnTab && !this.isComposing) {
+        if (this.selectOnTab && !this.isComposing && this.open) {
           this.typeAheadSelect()
         }
       },
@@ -1064,6 +1064,8 @@ export default {
      * @param value
      */
     updateValue(value) {
+      console.trace();
+
       if (typeof this.value === 'undefined') {
         // Vue select has to manage value
         this.$data._value = value

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -1064,8 +1064,6 @@ export default {
      * @param value
      */
     updateValue(value) {
-      console.trace();
-
       if (typeof this.value === 'undefined') {
         // Vue select has to manage value
         this.$data._value = value

--- a/tests/unit/Selecting.spec.js
+++ b/tests/unit/Selecting.spec.js
@@ -50,7 +50,7 @@ describe('VS - Selecting Values', () => {
     expect(Select.selectedValue).toEqual(Select.value)
   })
 
-  it('can select an option on tab', () => {
+  it('can select an option on tab while open', async () => {
     const Select = shallowMount(VueSelect, {
       propsData: {
         selectOnTab: true,
@@ -59,9 +59,26 @@ describe('VS - Selecting Values', () => {
 
     const spy = jest.spyOn(Select.vm, 'typeAheadSelect')
 
+    Select.findComponent({ ref: 'search' }).trigger('focus');
     Select.findComponent({ ref: 'search' }).trigger('keydown.tab')
 
-    expect(spy).toHaveBeenCalledWith()
+    expect(spy).toHaveBeenCalledTimes(1);
+  })
+
+  it('cannot select an option on tab while closed', async () => {
+    const Select = shallowMount(VueSelect, {
+      propsData: {
+        selectOnTab: true,
+      },
+    })
+
+    const spy = jest.spyOn(Select.vm, 'typeAheadSelect')
+
+    Select.findComponent({ ref: 'search' }).trigger('focus');
+    Select.findComponent({ ref: 'search' }).trigger('blur');
+    Select.findComponent({ ref: 'search' }).trigger('keydown.tab')
+
+    expect(spy).toHaveBeenCalledTimes(0);
   })
 
   it('can deselect a pre-selected object', () => {


### PR DESCRIPTION
Bug:
If a user selected on option from a dynamically populated list, and then used tab to navigate components, the option that would appear first for an empty search term would be used instead.

Fix:
This checks to see if the component is open when executing the `onTab` method.