### PR TITLE
Support web components build

### DIFF
--- a/src/css/global/variables.css
+++ b/src/css/global/variables.css
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
     --vs-colors--lightest: rgba(60, 60, 60, 0.26);
     --vs-colors--light: rgba(60, 60, 60, 0.5);
     --vs-colors--dark: #333;


### PR DESCRIPTION
Hi.

I've created a pull request to resolve Issue #1680. Added the `:host` selector so that CSS variables can be referenced in the Shadow DOM.

I investigated the following repositories and confirmed the solution to my problem.
https://github.com/kimulaco/vue-select-web-components-example