### PR TITLE
check arr.length instead of this.model (0) when using reduce

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -927,7 +927,7 @@ export default {
         this.clearSelection()
       }
 
-      if (this.value && this.isTrackingValues) {
+      if (this.isValueEmpty && this.isTrackingValues) {
         this.setInternalValueFromOptions(this.value)
       }
     },


### PR DESCRIPTION
Requirements:

Options are an async array of objects,
Custom "Reduce" prop is set
If the initial v-model value is set in 0, then the label will not change after receiving an asynchronous Options array