### PR TITLE
Option:deselected and option:deselecting are not getting emitted fix (#1430)

### DIFF
--- a/docs/content/api/events.md
+++ b/docs/content/api/events.md
@@ -25,6 +25,14 @@ Triggered when the dropdown is closed.
 this.$emit("close");
 ```
 
+## `clear`
+
+Triggered when clear button clicked, cleared value passed as an argument.
+
+```js
+this.$emit("clear", selectedOption);
+```
+
 ## `option:selecting` <Badge text="v3.11.0+" />
 
 Triggered after an option has been selected, <strong>before</strong> updating internal state. 

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -162,6 +162,7 @@ export default {
     'open',
     'close',
     'update:modelValue',
+    'clear',
     'search',
     'search:compositionstart',
     'search:compositionend',
@@ -1044,10 +1045,12 @@ export default {
     },
 
     /**
-     * Clears the currently selected value(s)
+     * Clears the currently selected value(s),
+     * triggers the clear event and passes cleared value as argument
      * @return {void}
      */
     clearSelection() {
+      this.$emit('clear', this.$data._value)
       this.updateValue(this.multiple ? [] : null)
     },
 

--- a/tests/unit/Deselecting.spec.js
+++ b/tests/unit/Deselecting.spec.js
@@ -143,6 +143,7 @@ describe('Removing values', () => {
 
       expect(Select.emitted()['update:modelValue']).toEqual([[null]])
       expect(Select.vm.selectedValue).toEqual([])
+      expect(Select.emitted()['clear']).toEqual([['foo']])
     })
 
     it('should be disabled when component is disabled', () => {


### PR DESCRIPTION
This pr adds 'clear' event which triggered by 'x' button click.
Cleared value passed as an argument to event.