### PR TITLE
fix: filterBy crash when searching 'ui' string

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -453,7 +453,7 @@ export default {
       type: Function,
       default(option, label, search) {
         return (
-          (label || '')
+          String(label || '')
             .toLocaleLowerCase()
             .indexOf(search.toLocaleLowerCase()) > -1
         )


### PR DESCRIPTION
## Issue
Entering 'ui' in the search box crashes the component due to:
- filterBy receives UI object instead of string when searching 'ui'
- Attempts toLowerCase() on object reference fails
- Affects only the specific search term 'ui'

## Fix
- Ensures string conversion before toLowerCase operation
- Handles edge case of UI object reference
- Zero-impact change for other search terms

## Testing
- Verified 'ui' search string works without error
- Confirmed other search terms behave normally