### PR TITLE
feat: headless ComboBox primitives

### DIFF
--- a/docs/plans/2026-02-16-headless-primitives.md
+++ b/docs/plans/2026-02-16-headless-primitives.md
@@ -16,6 +16,89 @@
 
 ---
 
+## Branching Strategy
+
+All headless primitives work happens on **feature branches** off `@beta/dev`. Each logical unit of work gets its own branch, is completed with passing tests, and merged back into `@beta/dev`.
+
+**Branch naming:**
+```
+@beta/dev                              ← integration branch (canonical)
+  └── feat/combobox-types              ← Task 2: types + keys
+  └── fix/use-click-away               ← Task 1: bugfix
+  └── feat/use-combobox-core           ← Tasks 3-7: composable
+  └── feat/combobox-components         ← Tasks 8-12: primitive components
+  └── feat/combobox-exports            ← Task 13: package exports
+  └── test/combobox-integration        ← Task 14: integration tests
+```
+
+**Merge strategy:** Each feature branch is merged into `@beta/dev` via fast-forward or merge commit. No squash -- we want the semantic commit history preserved for `semantic-release`.
+
+**Before creating a branch:**
+```bash
+git checkout @beta/dev
+git pull origin @beta/dev
+git checkout -b <branch-name>
+```
+
+**After completing work on a branch:**
+```bash
+git checkout @beta/dev
+git merge <branch-name>
+```
+
+## Commit Conventions
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) with `cz-conventional-changelog` and `semantic-release`. Every commit message MUST follow this format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+**Types:**
+- `feat` — new feature (triggers MINOR version bump)
+- `fix` — bug fix (triggers PATCH version bump)
+- `test` — adding or updating tests (no release)
+- `refactor` — code change that neither fixes a bug nor adds a feature (no release)
+- `chore` — build, CI, dependency changes (no release)
+- `docs` — documentation only (no release)
+
+**Scopes for this plan:**
+- `useClickAway` — the click-away hook
+- `types` — TypeScript type definitions
+- `useComboBox` — the core composable
+- `ComboBox` — the root provider component
+- `ComboBoxInput` — the search input primitive
+- `ComboBoxMenu` — the dropdown menu primitive
+- `ComboBoxOption` — the option primitive
+- `ComboBoxButton` — the toggle button primitive
+- `ComboBoxClear` — the clear button primitive
+
+**Breaking changes:** Any commit that introduces a breaking change MUST include a `BREAKING CHANGE:` footer in the commit body. This triggers a MAJOR version bump via `semantic-release`.
+
+```
+feat(ComboBox)!: replace ListBoxKey injection with ComboBoxKey
+
+BREAKING CHANGE: The provide/inject key has been renamed from
+ListBoxKey to ComboBoxKey. Any code injecting ListBoxKey must
+update to use ComboBoxKey instead.
+```
+
+**Known breaking changes to track:**
+- `ListBoxKey` renamed to `ComboBoxKey` (injection key)
+- `ListBoxProps` / `ResolvedListBoxProps` types replaced by `ComboBoxProps` / `ComboBoxContext`
+- `ComboBoxOption` now requires an `index` prop
+- `StyledComboBox` API will change once primitives are finalized
+- The `value` prop was already renamed to `modelValue` in a prior beta (documented in #1597)
+- SCSS was already removed in a prior beta (documented in #1597)
+
+These breaking changes are acceptable within the `beta` prerelease channel. They will be collected into the v4 upgrade guide (Plan 3, Phase C).
+
+---
+
 ## Task 1: Fix useClickAway Bug + Add Tests
 
 The current `useClickAway.ts` has a critical bug: `removeClickAwayListener` creates a new arrow function each call, so `document.removeEventListener` never actually removes the listener. The handler reference must be stored.
@@ -123,7 +206,14 @@ Expected: All 4 tests PASS
 
 ```bash
 git add src/hooks/useClickAway.ts tests/unit/hooks/useClickAway.spec.ts
-git commit -m "fix(useClickAway): store handler reference so removeEventListener works"
+git commit -m "$(cat <<'EOF'
+fix(useClickAway): store handler reference so removeEventListener works
+
+The previous implementation created a new arrow function in
+removeClickAwayListener, so document.removeEventListener never
+matched the original handler. Now the handler is stored and reused.
+EOF
+)"
 ```
 
 ---
@@ -304,7 +394,14 @@ Expected: May have errors in existing ComboBox files that reference old types. T
 
 ```bash
 git add src/types.ts src/keys.ts
-git commit -m "feat(types): define ComboBoxProps and ComboBoxContext interfaces"
+git commit -m "$(cat <<'EOF'
+feat(types): define ComboBoxProps and ComboBoxContext interfaces
+
+BREAKING CHANGE: ListBoxProps and ResolvedListBoxProps types are
+replaced by ComboBoxProps and ComboBoxContext. The ListBoxKey
+injection key is replaced by ComboBoxKey.
+EOF
+)"
 ```
 
 ---
@@ -1009,7 +1106,14 @@ onUnmounted(() => removeClickAwayListener(el.value))
 
 ```bash
 git add src/components/ComboBox/ComboBox.vue tests/unit/ComboBox/ComboBox.spec.ts
-git commit -m "feat(ComboBox): wire up useComboBox composable with provide/inject"
+git commit -m "$(cat <<'EOF'
+feat(ComboBox): wire up useComboBox composable with provide/inject
+
+BREAKING CHANGE: ComboBox now provides ComboBoxContext (via ComboBoxKey)
+instead of the previous ResolvedListBoxProps (via ListBoxKey). Child
+components must inject ComboBoxKey to access the expanded context.
+EOF
+)"
 ```
 
 ---
@@ -1131,7 +1235,14 @@ function onBlur() {
 
 ```bash
 git add src/components/ComboBox/ComboBoxInput.vue tests/unit/ComboBox/ComboBoxInput.spec.ts
-git commit -m "feat(ComboBoxInput): full keyboard nav, ARIA, and IME support"
+git commit -m "$(cat <<'EOF'
+feat(ComboBoxInput): full keyboard nav, ARIA, and IME support
+
+BREAKING CHANGE: ComboBoxInput now renders a fully controlled input
+with ARIA attributes and keyboard handlers. The previous uncontrolled
+input with no bindings is replaced.
+EOF
+)"
 ```
 
 ---
@@ -1269,7 +1380,15 @@ function onClick() {
 
 ```bash
 git add src/components/ComboBox/ComboBoxOption.vue tests/unit/ComboBox/ComboBoxOption.spec.ts
-git commit -m "feat(ComboBoxOption): ARIA option with selection, highlight, and disabled states"
+git commit -m "$(cat <<'EOF'
+feat(ComboBoxOption)!: add ARIA, highlight, and disabled states
+
+BREAKING CHANGE: ComboBoxOption now requires an `index` prop for
+ARIA and typeahead pointer tracking. The `value` prop type is
+narrowed to OptionValue. Slot bindings now include isHighlighted
+and isDisabled alongside isSelected.
+EOF
+)"
 ```
 
 ---

--- a/docs/plans/2026-02-16-v4-release-design.md
+++ b/docs/plans/2026-02-16-v4-release-design.md
@@ -168,6 +168,22 @@ Plan 3: Documentation                  │      backward compat)
 - **Plan 3 Phase C** (upgrade guide, headless docs) waits for Plans 1 + 2
 - **Plan 4** (release) waits for everything
 
+## Branching & Commit Strategy
+
+**Integration branch:** `@beta/dev` is the canonical integration branch for all v4 work.
+
+**Feature branches:** Each workstream/task gets an isolated feature branch off `@beta/dev`:
+- `feat/combobox-*` -- headless primitives work
+- `fix/*` -- bugfixes
+- `docs/*` -- documentation work
+- `chore/*` -- build/CI/dependency changes
+
+**Commit convention:** [Conventional Commits](https://www.conventionalcommits.org/) via `cz-conventional-changelog`. This project uses `semantic-release` to auto-publish from the `beta` release branch.
+
+**Breaking changes:** Any commit with a breaking change MUST include a `BREAKING CHANGE:` footer. All breaking changes are tracked in the implementation plans and will be collected into the v4 upgrade guide.
+
+**Release flow:** `@beta/dev` -> `beta` (prerelease channel) -> `master` (stable v4.0.0)
+
 ## Key Decisions Made
 
 1. **Ship both headless primitives and styled wrapper** in v4.0
@@ -176,6 +192,8 @@ Plan 3: Documentation                  │      backward compat)
 4. **Parallel workstreams, ship when ready** -- no artificial timeline pressure
 5. **v3 docs archived under `/v3/` path** via content migration into Nuxt
 6. **Each plan gets its own detailed implementation plan** in a separate planning session
+7. **Feature branches** for isolated work, merged back into `@beta/dev`
+8. **Semantic commits** with `BREAKING CHANGE:` footers for all breaking changes
 
 ## Current Project State (as of 2026-02-16)
 

--- a/src/components/ComboBox/ComboBox.vue
+++ b/src/components/ComboBox/ComboBox.vue
@@ -1,72 +1,61 @@
 <script setup lang="ts">
-import { ListBoxKey } from '@/keys'
-import type { ComputedRef } from 'vue'
-import {
-  provide,
-  computed,
-  reactive,
-  watch,
-  onMounted,
-  ref,
-  onUnmounted,
-} from 'vue'
+import { provide, ref, onMounted, onUnmounted } from 'vue'
+import { useComboBox } from '@/hooks/useComboBox'
 import { useClickAway } from '@/hooks/useClickAway'
-import type {
-  InjectedListBoxProps,
-  ListBoxProps,
-  ResolvedListBoxProps,
-  VueSelectValue,
-} from '@/types'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxProps } from '@/types'
 
-const emit = defineEmits(['update:modelValue', 'update:open', 'open', 'close'])
-
-const props = withDefaults(defineProps<ListBoxProps>(), {
-  open: undefined,
+const props = withDefaults(defineProps<ComboBoxProps>(), {
+  options: () => [],
+  multiple: false,
+  filterable: true,
+  taggable: false,
+  pushTags: false,
+  clearable: true,
+  closeOnSelect: true,
+  clearSearchOnSelect: true,
+  disabled: false,
+  label: 'label',
+  loading: false,
+  noDrop: false,
+  deselectFromDropdown: false,
+  autoscroll: true,
+  placeholder: '',
 })
 
+const emit = defineEmits<{
+  'update:modelValue': [value: unknown]
+  'update:open': [value: boolean]
+  open: []
+  close: []
+  search: [search: string, toggleLoading: (value?: boolean) => void]
+  'option:created': [option: unknown]
+  'option:selecting': [option: unknown]
+  'option:selected': [option: unknown]
+  'option:deselecting': [option: unknown]
+  'option:deselected': [option: unknown]
+}>()
+
+const ctx = useComboBox(props, emit)
+provide(ComboBoxKey, ctx)
+
+// Click-away to close
 const el = ref<HTMLElement>()
-const state = reactive<{
-  open: boolean
-}>({
-  open: props.open === undefined ? false : props.open,
+const { addClickAwayListener, removeClickAwayListener } = useClickAway(() => {
+  ctx.setOpen(false)
 })
-
-watch(
-  () => state.open,
-  (open) => emit('update:open', open),
-)
-
-const inputText = ref('')
-
-const isOpen = computed<boolean>(() => {
-  if (props.open !== undefined) {
-    return props.open
-  }
-  return state.open
-})
-
-const { addClickAwayListener, removeClickAwayListener } = useClickAway(
-  () => (state.open = false),
-)
-
 onMounted(() => addClickAwayListener(el.value))
 onUnmounted(() => removeClickAwayListener(el.value))
-
-provide<InjectedListBoxProps>(
-  ListBoxKey,
-  computed<ResolvedListBoxProps>(() => ({
-    open: isOpen.value,
-    modelValue: props.modelValue,
-    inputText: inputText.value,
-    toggleOpen: () => (state.open = !state.open),
-    setModelValue: (modelValue) => emit('update:modelValue', modelValue),
-    setInputText: (value: string) => (inputText.value = value),
-  })),
-)
 </script>
 
 <template>
-  <div tabindex="0" role="combobox" ref="el">
-    <slot></slot>
+  <div
+    ref="el"
+    role="combobox"
+    :aria-expanded="String(ctx.open.value)"
+    :aria-owns="`vs-${ctx.uid.value}-listbox`"
+    :aria-label="placeholder || undefined"
+  >
+    <slot />
   </div>
 </template>

--- a/src/components/ComboBox/ComboBox.vue
+++ b/src/components/ComboBox/ComboBox.vue
@@ -49,13 +49,7 @@ onUnmounted(() => removeClickAwayListener(el.value))
 </script>
 
 <template>
-  <div
-    ref="el"
-    role="combobox"
-    :aria-expanded="String(ctx.open.value)"
-    :aria-owns="`vs-${ctx.uid.value}-listbox`"
-    :aria-label="placeholder || undefined"
-  >
+  <div ref="el">
     <slot />
   </div>
 </template>

--- a/src/components/ComboBox/ComboBoxButton.vue
+++ b/src/components/ComboBox/ComboBoxButton.vue
@@ -1,28 +1,20 @@
 <script setup lang="ts">
-import { inject } from 'vue'
-import { ListBoxKey } from '@/keys'
+import { inject, computed } from 'vue'
+import { ComboBoxKey } from '@/keys'
 
-withDefaults(
-  defineProps<{
-    as?: string
-  }>(),
-  {
-    as: 'button',
-  },
-)
-
-const listBoxProps = inject(ListBoxKey)
+const ctx = inject(ComboBoxKey)!
 </script>
 
 <template>
-  <Component
-    :is="as"
-    tabindex="0"
+  <button
     type="button"
-    aria-haspopup="true"
-    :aria-expanded="listBoxProps.open"
-    @click="listBoxProps.toggleOpen"
+    aria-haspopup="listbox"
+    :aria-expanded="String(ctx.open.value)"
+    :aria-controls="`vs-${ctx.uid.value}-listbox`"
+    :disabled="ctx.disabled.value || undefined"
+    @click="ctx.toggleOpen()"
+    @mousedown.prevent
   >
-    <slot></slot>
-  </Component>
+    <slot />
+  </button>
 </template>

--- a/src/components/ComboBox/ComboBoxButton.vue
+++ b/src/components/ComboBox/ComboBoxButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { inject, computed } from 'vue'
+import { inject } from 'vue'
 import { ComboBoxKey } from '@/keys'
 
 const ctx = inject(ComboBoxKey)

--- a/src/components/ComboBox/ComboBoxButton.vue
+++ b/src/components/ComboBox/ComboBoxButton.vue
@@ -2,7 +2,8 @@
 import { inject, computed } from 'vue'
 import { ComboBoxKey } from '@/keys'
 
-const ctx = inject(ComboBoxKey)!
+const ctx = inject(ComboBoxKey)
+if (!ctx) throw new Error('ComboBoxButton must be used inside a ComboBox component')
 </script>
 
 <template>

--- a/src/components/ComboBox/ComboBoxClear.vue
+++ b/src/components/ComboBox/ComboBoxClear.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { inject } from 'vue'
+import { ComboBoxKey } from '@/keys'
+
+const ctx = inject(ComboBoxKey)!
+</script>
+
+<template>
+  <button
+    v-show="!ctx.isValueEmpty.value && ctx.clearable.value"
+    type="button"
+    aria-label="Clear selection"
+    @click="ctx.clearSelection()"
+    @mousedown.prevent
+  >
+    <slot />
+  </button>
+</template>

--- a/src/components/ComboBox/ComboBoxClear.vue
+++ b/src/components/ComboBox/ComboBoxClear.vue
@@ -2,7 +2,8 @@
 import { inject } from 'vue'
 import { ComboBoxKey } from '@/keys'
 
-const ctx = inject(ComboBoxKey)!
+const ctx = inject(ComboBoxKey)
+if (!ctx) throw new Error('ComboBoxClear must be used inside a ComboBox component')
 </script>
 
 <template>

--- a/src/components/ComboBox/ComboBoxInput.vue
+++ b/src/components/ComboBox/ComboBoxInput.vue
@@ -1,13 +1,83 @@
 <script setup lang="ts">
-import { inject } from 'vue'
-import { ListBoxKey } from '@/keys'
+import { inject, ref, computed } from 'vue'
+import { ComboBoxKey } from '@/keys'
 
-const listBoxProps = inject(ListBoxKey)
+const ctx = inject(ComboBoxKey)!
+const isComposing = ref(false)
+
+const attrs = computed(() => ({
+  type: 'search',
+  role: 'searchbox',
+  autocomplete: 'off',
+  'aria-autocomplete': 'list' as const,
+  'aria-controls': `vs-${ctx.uid.value}-listbox`,
+  'aria-activedescendant':
+    ctx.typeAheadPointer.value > -1
+      ? `vs-${ctx.uid.value}-option-${ctx.typeAheadPointer.value}`
+      : undefined,
+  disabled: ctx.disabled.value || undefined,
+  value: ctx.search.value,
+  placeholder: ctx.placeholder.value || undefined,
+}))
+
+function onInput(e: Event) {
+  ctx.setSearch((e.target as HTMLInputElement).value)
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (isComposing.value) return
+
+  switch (e.key) {
+    case 'ArrowDown':
+      e.preventDefault()
+      ctx.typeAheadDown()
+      if (!ctx.open.value) ctx.setOpen(true)
+      break
+    case 'ArrowUp':
+      e.preventDefault()
+      ctx.typeAheadUp()
+      if (!ctx.open.value) ctx.setOpen(true)
+      break
+    case 'Enter':
+      e.preventDefault()
+      if (ctx.open.value) ctx.typeAheadSelect()
+      break
+    case 'Escape':
+      if (ctx.isSearching.value) {
+        ctx.setSearch('')
+      } else {
+        ctx.setOpen(false)
+      }
+      break
+    case 'Backspace':
+      if (!ctx.search.value && ctx.multiple.value && !ctx.isValueEmpty.value) {
+        const last = ctx.selectedValue.value[ctx.selectedValue.value.length - 1]
+        ctx.deselect(last)
+      }
+      break
+  }
+}
+
+function onFocus() {
+  if (!ctx.disabled.value) {
+    ctx.setOpen(true)
+  }
+}
+
+function onBlur() {
+  ctx.setOpen(false)
+  ctx.setSearch('')
+}
 </script>
 
 <template>
   <input
-    type="search"
-    @input="({ target }) => listBoxProps?.setInputText(target.value)"
+    v-bind="attrs"
+    @input="onInput"
+    @keydown="onKeydown"
+    @focus="onFocus"
+    @blur="onBlur"
+    @compositionstart="isComposing = true"
+    @compositionend="isComposing = false"
   />
 </template>

--- a/src/components/ComboBox/ComboBoxInput.vue
+++ b/src/components/ComboBox/ComboBoxInput.vue
@@ -2,14 +2,16 @@
 import { inject, ref, computed } from 'vue'
 import { ComboBoxKey } from '@/keys'
 
-const ctx = inject(ComboBoxKey)!
+const ctx = inject(ComboBoxKey)
+if (!ctx) throw new Error('ComboBoxInput must be used inside a ComboBox component')
 const isComposing = ref(false)
 
 const attrs = computed(() => ({
   type: 'search',
-  role: 'searchbox',
+  role: 'combobox',
   autocomplete: 'off',
   'aria-autocomplete': 'list' as const,
+  'aria-expanded': String(ctx.open.value),
   'aria-controls': `vs-${ctx.uid.value}-listbox`,
   'aria-activedescendant':
     ctx.typeAheadPointer.value > -1

--- a/src/components/ComboBox/ComboBoxMenu.vue
+++ b/src/components/ComboBox/ComboBoxMenu.vue
@@ -2,13 +2,14 @@
 import { inject, ref, watch, nextTick } from 'vue'
 import { ComboBoxKey } from '@/keys'
 
-const ctx = inject(ComboBoxKey)!
+const ctx = inject(ComboBoxKey)
+if (!ctx) throw new Error('ComboBoxMenu must be used inside a ComboBox component')
 const menuEl = ref<HTMLElement>()
 
 // Auto-scroll to keep highlighted option visible
 watch(() => ctx.typeAheadPointer.value, async (pointer) => {
   await nextTick()
-  if (!menuEl.value || pointer < 0) return
+  if (!ctx.autoscroll.value || !menuEl.value || pointer < 0) return
   const option = menuEl.value.children[pointer] as HTMLElement | undefined
   if (!option) return
 

--- a/src/components/ComboBox/ComboBoxMenu.vue
+++ b/src/components/ComboBox/ComboBoxMenu.vue
@@ -10,7 +10,7 @@ const menuEl = ref<HTMLElement>()
 watch(() => ctx.typeAheadPointer.value, async (pointer) => {
   await nextTick()
   if (!ctx.autoscroll.value || !menuEl.value || pointer < 0) return
-  const option = menuEl.value.children[pointer] as HTMLElement | undefined
+  const option = menuEl.value.querySelector<HTMLElement>(`#vs-${ctx.uid.value}-option-${pointer}`)
   if (!option) return
 
   const menuRect = menuEl.value.getBoundingClientRect()

--- a/src/components/ComboBox/ComboBoxMenu.vue
+++ b/src/components/ComboBox/ComboBoxMenu.vue
@@ -1,21 +1,37 @@
 <script setup lang="ts">
-import { defineProps, inject } from 'vue'
-import { ListBoxKey } from '@/keys'
+import { inject, ref, watch, nextTick } from 'vue'
+import { ComboBoxKey } from '@/keys'
 
-withDefaults(
-  defineProps<{
-    as?: string
-  }>(),
-  {
-    as: 'div',
-  },
-)
+const ctx = inject(ComboBoxKey)!
+const menuEl = ref<HTMLElement>()
 
-const listBoxProps = inject(ListBoxKey)
+// Auto-scroll to keep highlighted option visible
+watch(() => ctx.typeAheadPointer.value, async (pointer) => {
+  await nextTick()
+  if (!menuEl.value || pointer < 0) return
+  const option = menuEl.value.children[pointer] as HTMLElement | undefined
+  if (!option) return
+
+  const menuRect = menuEl.value.getBoundingClientRect()
+  const optionRect = option.getBoundingClientRect()
+
+  if (optionRect.bottom > menuRect.bottom) {
+    menuEl.value.scrollTop += optionRect.bottom - menuRect.bottom
+  } else if (optionRect.top < menuRect.top) {
+    menuEl.value.scrollTop -= menuRect.top - optionRect.top
+  }
+})
 </script>
 
 <template>
-  <Component :is="as" v-show="listBoxProps.open">
-    <slot></slot>
-  </Component>
+  <div
+    v-show="ctx.open.value && !ctx.noDrop.value"
+    ref="menuEl"
+    :id="`vs-${ctx.uid.value}-listbox`"
+    role="listbox"
+    tabindex="-1"
+    @mousedown.prevent
+  >
+    <slot />
+  </div>
 </template>

--- a/src/components/ComboBox/ComboBoxOption.vue
+++ b/src/components/ComboBox/ComboBoxOption.vue
@@ -8,7 +8,8 @@ const props = defineProps<{
   index: number
 }>()
 
-const ctx = inject(ComboBoxKey)!
+const ctx = inject(ComboBoxKey)
+if (!ctx) throw new Error('ComboBoxOption must be used inside a ComboBox component')
 
 const isSelected = computed(() => ctx.isOptionSelected(props.value))
 const isHighlighted = computed(() => ctx.isOptionHighlighted(props.index))
@@ -16,9 +17,9 @@ const isDisabled = computed(() => !ctx.isOptionSelectable(props.value))
 
 function onClick() {
   if (isDisabled.value) return
-  if (isSelected.value) {
+  if (isSelected.value && ctx.deselectFromDropdown.value) {
     ctx.deselect(props.value)
-  } else {
+  } else if (!isSelected.value) {
     ctx.select(props.value)
   }
 }
@@ -28,7 +29,7 @@ function onClick() {
   <div
     :id="`vs-${ctx.uid.value}-option-${index}`"
     role="option"
-    :aria-selected="isSelected || undefined"
+    :aria-selected="String(isSelected)"
     :aria-disabled="isDisabled || undefined"
     @click="onClick"
     @mouseover="ctx.typeAheadPointer.value = index"

--- a/src/components/ComboBox/ComboBoxOption.vue
+++ b/src/components/ComboBox/ComboBoxOption.vue
@@ -1,26 +1,38 @@
 <script setup lang="ts">
-import { computed, defineProps, inject } from 'vue'
-import { ListBoxKey } from '@/keys'
+import { inject, computed } from 'vue'
+import { ComboBoxKey } from '@/keys'
+import type { OptionValue } from '@/types'
 
-const props = withDefaults(
-  defineProps<{
-    as?: string
-    value: unknown
-  }>(),
-  {
-    as: 'div',
-  },
-)
+const props = defineProps<{
+  value: OptionValue
+  index: number
+}>()
 
-const listBoxProps = inject(ListBoxKey)
+const ctx = inject(ComboBoxKey)!
 
-const isSelected = computed(() => {
-  return listBoxProps?.value.modelValue === props.value
-})
+const isSelected = computed(() => ctx.isOptionSelected(props.value))
+const isHighlighted = computed(() => ctx.isOptionHighlighted(props.index))
+const isDisabled = computed(() => !ctx.isOptionSelectable(props.value))
+
+function onClick() {
+  if (isDisabled.value) return
+  if (isSelected.value) {
+    ctx.deselect(props.value)
+  } else {
+    ctx.select(props.value)
+  }
+}
 </script>
 
 <template>
-  <Component :is="as" @click="() => listBoxProps.setModelValue(value)">
-    <slot v-bind="{ isSelected }"></slot>
-  </Component>
+  <div
+    :id="`vs-${ctx.uid.value}-option-${index}`"
+    role="option"
+    :aria-selected="isSelected || undefined"
+    :aria-disabled="isDisabled || undefined"
+    @click="onClick"
+    @mouseover="ctx.typeAheadPointer.value = index"
+  >
+    <slot v-bind="{ isSelected, isHighlighted, isDisabled }" />
+  </div>
 </template>

--- a/src/components/ComboBox/StyledComboBox.vue
+++ b/src/components/ComboBox/StyledComboBox.vue
@@ -3,7 +3,6 @@ import { ref, watch } from 'vue'
 import ComboBox from '@/components/ComboBox/ComboBox.vue'
 import ComboBoxInput from '@/components/ComboBox/ComboBoxInput.vue'
 import ComboBoxMenu from '@/components/ComboBox/ComboBoxMenu.vue'
-import ComboBoxOption from '@/components/ComboBox/ComboBoxOption.vue'
 import ComboBoxButton from '@/components/ComboBox/ComboBoxButton.vue'
 import type { VueSelectOption } from '@/types'
 

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -13,7 +13,7 @@ export function useClickAway(callback: () => void) {
     document.addEventListener('click', handler)
   }
 
-  function removeClickAwayListener(_el: HTMLElement | undefined) {
+  function removeClickAwayListener() {
     if (handler) {
       document.removeEventListener('click', handler)
       handler = null

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -1,21 +1,24 @@
-export function useClickAway(callback: () => void): {
-  addClickAwayListener: (el: HTMLElement | undefined) => void
-  removeClickAwayListener: (el: HTMLElement | undefined) => void
-} {
-  function clickedOutside(el: HTMLElement | undefined, event: MouseEvent) {
-    if (el && !(el == event.target || el?.contains(event.target))) {
-      callback()
+export function useClickAway(callback: () => void) {
+  let handler: ((event: Event) => void) | null = null
+
+  function addClickAwayListener(el: HTMLElement | undefined) {
+    if (!el) return
+
+    handler = (event: Event) => {
+      if (el && !(el === event.target || el.contains(event.target as Node))) {
+        callback()
+      }
+    }
+
+    document.addEventListener('click', handler)
+  }
+
+  function removeClickAwayListener(_el: HTMLElement | undefined) {
+    if (handler) {
+      document.removeEventListener('click', handler)
+      handler = null
     }
   }
 
-  return {
-    addClickAwayListener: (el) =>
-      document.addEventListener('click', (event: MouseEvent) =>
-        clickedOutside(el, event)
-      ),
-    removeClickAwayListener: (el) =>
-      document.removeEventListener('click', (event: MouseEvent) =>
-        clickedOutside(el, event)
-      ),
-  }
+  return { addClickAwayListener, removeClickAwayListener }
 }

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -11,6 +11,7 @@ export function useComboBox(
   const search = ref('')
   const typeAheadPointer = ref(-1)
   const isLoading = ref(false)
+  const pushedTags = ref<OptionValue[]>([])
 
   // Generate a stable uid once per instance
   const stableUid = String(Math.random()).slice(2, 8)
@@ -34,10 +35,6 @@ export function useComboBox(
   const taggable = computed(() => props.taggable ?? false)
   const placeholder = computed(() => props.placeholder ?? '')
   const uid = computed(() => props.uid ?? stableUid)
-
-  // Stubs for filtering -- expanded in Task 4
-  const filteredOptions = computed<OptionValue[]>(() => props.options ?? [])
-  const optionList = computed<OptionValue[]>(() => props.options ?? [])
 
   // --- Option helpers ---
 
@@ -71,6 +68,58 @@ export function useComboBox(
   function isOptionHighlighted(index: number): boolean {
     return typeAheadPointer.value === index
   }
+
+  // --- Filtering helpers ---
+
+  function defaultFilterBy(option: OptionValue, label: string, search: string): boolean {
+    return label.toLocaleLowerCase().includes(search.toLocaleLowerCase())
+  }
+
+  function maybeAddTaggableOption(options: OptionValue[]): OptionValue[] {
+    if (!taggable.value || !search.value) return options
+
+    // Create the tag option
+    const tagOption = props.createOption
+      ? props.createOption(search.value)
+      : search.value
+
+    // Don't add if an option with the same key already exists
+    const tagKey = getOptionKey(tagOption)
+    const alreadyExists = options.some((o) => getOptionKey(o) === tagKey)
+
+    if (alreadyExists) return options
+    return [tagOption, ...options]
+  }
+
+  // --- Filtering computeds ---
+
+  const optionList = computed<OptionValue[]>(() => [
+    ...(props.options ?? []),
+    ...pushedTags.value,
+  ])
+
+  const filteredOptions = computed<OptionValue[]>(() => {
+    const opts = optionList.value
+
+    // Custom filter function takes priority
+    if (props.filter) {
+      return props.filter(opts, search.value)
+    }
+
+    // If not filterable or no search, return all
+    if (!filterable.value || !search.value) {
+      return maybeAddTaggableOption(opts)
+    }
+
+    // Default filtering logic
+    const filterFn = props.filterBy ?? defaultFilterBy
+    const filtered = opts.filter((option) => {
+      const label = getOptionLabel(option)
+      return filterFn(option, label, search.value)
+    })
+
+    return maybeAddTaggableOption(filtered)
+  })
 
   // --- Open state ---
 

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -5,7 +5,7 @@ let uidCounter = 0
 
 export function useComboBox(
   props: ComboBoxProps,
-  emit: (...args: any[]) => void
+  emit: (event: string, ...args: unknown[]) => void
 ): ComboBoxContext {
   // --- State ---
 

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -10,7 +10,7 @@ export function useComboBox(
   const open = ref(false)
   const search = ref('')
   const typeAheadPointer = ref(-1)
-  const isLoading = ref(false)
+  const isLoading = ref(props.loading ?? false)
   const pushedTags = ref<OptionValue[]>([])
 
   // Generate a stable uid once per instance
@@ -71,6 +71,19 @@ export function useComboBox(
 
   function isOptionHighlighted(index: number): boolean {
     return typeAheadPointer.value === index
+  }
+
+  // --- Tagging helpers ---
+
+  /**
+   * Checks if the option is a new tag candidate — i.e., its key doesn't exist
+   * in the original options list (props.options) or in pushedTags.
+   */
+  function isNewTagCandidate(option: OptionValue): boolean {
+    const opts = props.options ?? []
+    const optKey = getOptionKey(option)
+    return !opts.some((o) => getOptionKey(o) === optKey) &&
+      !pushedTags.value.some((o) => getOptionKey(o) === optKey)
   }
 
   // --- Filtering helpers ---
@@ -150,11 +163,20 @@ export function useComboBox(
 
   function setSearch(value: string) {
     search.value = value
+    emit('search', value, toggleLoading)
   }
 
   // --- Selection ---
 
   function select(option: OptionValue) {
+    // Check if this is a new tag (not in the original options or pushedTags)
+    if (taggable.value && isNewTagCandidate(option)) {
+      emit('option:created', option)
+      if (props.pushTags) {
+        pushedTags.value = [...pushedTags.value, option]
+      }
+    }
+
     emit('option:selecting', option)
     const emitValue = props.reduce ? props.reduce(option) : option
     if (props.multiple) {

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -20,9 +20,13 @@ export function useComboBox(
 
   const selectedValue = computed<OptionValue[]>(() => {
     const v = props.modelValue
-    if (Array.isArray(v)) return v
-    if (v != null) return [v]
-    return []
+    const values = Array.isArray(v) ? v : v != null ? [v] : []
+
+    if (!props.reduce) return values as OptionValue[]
+
+    // When reduce is in use, modelValue contains reduced values.
+    // Map them back to full option objects.
+    return values.map((val) => findOptionFromReducedValue(val) ?? val as OptionValue)
   })
 
   const isValueEmpty = computed(() => selectedValue.value.length === 0)
@@ -121,6 +125,16 @@ export function useComboBox(
     return maybeAddTaggableOption(filtered)
   })
 
+  // --- Reduce helpers ---
+
+  function findOptionFromReducedValue(reducedValue: unknown): OptionValue | undefined {
+    const opts = optionList.value
+    return opts.find((option) => {
+      const reduced = props.reduce ? props.reduce(option) : option
+      return JSON.stringify(reduced) === JSON.stringify(reducedValue)
+    })
+  }
+
   // --- Open state ---
 
   function setOpen(value: boolean) {
@@ -142,14 +156,15 @@ export function useComboBox(
 
   function select(option: OptionValue) {
     emit('option:selecting', option)
+    const emitValue = props.reduce ? props.reduce(option) : option
     if (props.multiple) {
       const current = Array.isArray(props.modelValue)
         ? [...props.modelValue]
         : []
-      current.push(option)
+      current.push(emitValue)
       emit('update:modelValue', current)
     } else {
-      emit('update:modelValue', option)
+      emit('update:modelValue', emitValue)
     }
     emit('option:selected', option)
   }
@@ -159,9 +174,13 @@ export function useComboBox(
     const current = Array.isArray(props.modelValue)
       ? [...props.modelValue]
       : []
-    const filtered = current.filter(
-      (v) => getOptionKey(v) !== getOptionKey(option)
-    )
+    const reducedKey = props.reduce
+      ? JSON.stringify(props.reduce(option))
+      : getOptionKey(option)
+    const filtered = current.filter((v) => {
+      const vKey = props.reduce ? JSON.stringify(v) : getOptionKey(v as OptionValue)
+      return vKey !== reducedKey
+    })
     emit('update:modelValue', filtered)
     emit('option:deselected', option)
   }

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -1,5 +1,7 @@
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import type { ComboBoxProps, ComboBoxContext, OptionValue } from '@/types'
+
+let uidCounter = 0
 
 export function useComboBox(
   props: ComboBoxProps,
@@ -7,14 +9,24 @@ export function useComboBox(
 ): ComboBoxContext {
   // --- State ---
 
-  const open = ref(false)
+  const open = ref(props.open ?? false)
   const search = ref('')
   const typeAheadPointer = ref(-1)
   const isLoading = ref(props.loading ?? false)
   const pushedTags = ref<OptionValue[]>([])
 
-  // Generate a stable uid once per instance
-  const stableUid = String(Math.random()).slice(2, 8)
+  // Generate a stable uid once per instance using a counter
+  const stableUid = String(++uidCounter)
+
+  // Sync controlled open prop
+  watch(() => props.open, (val) => {
+    if (val !== undefined) open.value = val
+  })
+
+  // Sync loading prop
+  watch(() => props.loading, (val) => {
+    if (val !== undefined) isLoading.value = val
+  })
 
   // --- Computed ---
 
@@ -39,6 +51,8 @@ export function useComboBox(
   const taggable = computed(() => props.taggable ?? false)
   const placeholder = computed(() => props.placeholder ?? '')
   const uid = computed(() => props.uid ?? stableUid)
+  const deselectFromDropdown = computed(() => props.deselectFromDropdown ?? false)
+  const autoscroll = computed(() => props.autoscroll ?? true)
 
   // --- Option helpers ---
 
@@ -118,9 +132,9 @@ export function useComboBox(
   const filteredOptions = computed<OptionValue[]>(() => {
     const opts = optionList.value
 
-    // Custom filter function takes priority
+    // Custom filter function takes priority, but still add taggable option
     if (props.filter) {
-      return props.filter(opts, search.value)
+      return maybeAddTaggableOption(props.filter(opts, search.value))
     }
 
     // If not filterable or no search, return all
@@ -151,7 +165,9 @@ export function useComboBox(
   // --- Open state ---
 
   function setOpen(value: boolean) {
+    if (open.value === value) return
     open.value = value
+    emit('update:open', value)
     emit(value ? 'open' : 'close')
   }
 
@@ -163,6 +179,7 @@ export function useComboBox(
 
   function setSearch(value: string) {
     search.value = value
+    typeAheadPointer.value = -1
     emit('search', value, toggleLoading)
   }
 
@@ -180,15 +197,24 @@ export function useComboBox(
     emit('option:selecting', option)
     const emitValue = props.reduce ? props.reduce(option) : option
     if (props.multiple) {
-      const current = Array.isArray(props.modelValue)
-        ? [...props.modelValue]
-        : []
-      current.push(emitValue)
-      emit('update:modelValue', current)
+      if (!isOptionSelected(option)) {
+        const current = Array.isArray(props.modelValue)
+          ? [...props.modelValue]
+          : []
+        current.push(emitValue)
+        emit('update:modelValue', current)
+      }
     } else {
       emit('update:modelValue', emitValue)
     }
     emit('option:selected', option)
+
+    if (props.clearSearchOnSelect !== false) {
+      search.value = ''
+    }
+    if (props.closeOnSelect !== false) {
+      setOpen(false)
+    }
   }
 
   function deselect(option: OptionValue) {
@@ -218,15 +244,18 @@ export function useComboBox(
     if (opts.length === 0) return
 
     let next = typeAheadPointer.value + 1
-    // Wrap around
     if (next >= opts.length) next = 0
 
-    // Find next selectable option (with wrap protection)
-    const start = next
     let checked = 0
     while (!isOptionSelectable(opts[next]) && checked < opts.length) {
       next = (next + 1) % opts.length
       checked++
+    }
+
+    // If we checked all options and none are selectable, reset to -1
+    if (checked >= opts.length) {
+      typeAheadPointer.value = -1
+      return
     }
 
     typeAheadPointer.value = next
@@ -237,15 +266,18 @@ export function useComboBox(
     if (opts.length === 0) return
 
     let prev = typeAheadPointer.value - 1
-    // Wrap around
     if (prev < 0) prev = opts.length - 1
 
-    // Find previous selectable option (with wrap protection)
     let checked = 0
     while (!isOptionSelectable(opts[prev]) && checked < opts.length) {
       prev = prev - 1
       if (prev < 0) prev = opts.length - 1
       checked++
+    }
+
+    if (checked >= opts.length) {
+      typeAheadPointer.value = -1
+      return
     }
 
     typeAheadPointer.value = prev
@@ -283,6 +315,8 @@ export function useComboBox(
     isValueEmpty,
     isSearching,
     uid,
+    deselectFromDropdown,
+    autoscroll,
 
     // Methods
     select,

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -170,11 +170,55 @@ export function useComboBox(
     emit('update:modelValue', props.multiple ? [] : null)
   }
 
-  // --- Stubs for later tasks ---
+  // --- TypeAhead navigation ---
 
-  function typeAheadUp() {}
-  function typeAheadDown() {}
-  function typeAheadSelect() {}
+  function typeAheadDown() {
+    const opts = filteredOptions.value
+    if (opts.length === 0) return
+
+    let next = typeAheadPointer.value + 1
+    // Wrap around
+    if (next >= opts.length) next = 0
+
+    // Find next selectable option (with wrap protection)
+    const start = next
+    let checked = 0
+    while (!isOptionSelectable(opts[next]) && checked < opts.length) {
+      next = (next + 1) % opts.length
+      checked++
+    }
+
+    typeAheadPointer.value = next
+  }
+
+  function typeAheadUp() {
+    const opts = filteredOptions.value
+    if (opts.length === 0) return
+
+    let prev = typeAheadPointer.value - 1
+    // Wrap around
+    if (prev < 0) prev = opts.length - 1
+
+    // Find previous selectable option (with wrap protection)
+    let checked = 0
+    while (!isOptionSelectable(opts[prev]) && checked < opts.length) {
+      prev = prev - 1
+      if (prev < 0) prev = opts.length - 1
+      checked++
+    }
+
+    typeAheadPointer.value = prev
+  }
+
+  function typeAheadSelect() {
+    const opts = filteredOptions.value
+    if (typeAheadPointer.value >= 0 && typeAheadPointer.value < opts.length) {
+      const option = opts[typeAheadPointer.value]
+      if (isOptionSelectable(option)) {
+        select(option)
+      }
+    }
+  }
 
   function toggleLoading(value?: boolean) {
     isLoading.value = value ?? !isLoading.value

--- a/src/hooks/useComboBox.ts
+++ b/src/hooks/useComboBox.ts
@@ -1,0 +1,171 @@
+import { ref, computed } from 'vue'
+import type { ComboBoxProps, ComboBoxContext, OptionValue } from '@/types'
+
+export function useComboBox(
+  props: ComboBoxProps,
+  emit: (...args: any[]) => void
+): ComboBoxContext {
+  // --- State ---
+
+  const open = ref(false)
+  const search = ref('')
+  const typeAheadPointer = ref(-1)
+  const isLoading = ref(false)
+
+  // Generate a stable uid once per instance
+  const stableUid = String(Math.random()).slice(2, 8)
+
+  // --- Computed ---
+
+  const selectedValue = computed<OptionValue[]>(() => {
+    const v = props.modelValue
+    if (Array.isArray(v)) return v
+    if (v != null) return [v]
+    return []
+  })
+
+  const isValueEmpty = computed(() => selectedValue.value.length === 0)
+  const isSearching = computed(() => search.value.length > 0)
+  const disabled = computed(() => props.disabled ?? false)
+  const multiple = computed(() => props.multiple ?? false)
+  const filterable = computed(() => props.filterable ?? true)
+  const noDrop = computed(() => props.noDrop ?? false)
+  const clearable = computed(() => props.clearable ?? true)
+  const taggable = computed(() => props.taggable ?? false)
+  const placeholder = computed(() => props.placeholder ?? '')
+  const uid = computed(() => props.uid ?? stableUid)
+
+  // Stubs for filtering -- expanded in Task 4
+  const filteredOptions = computed<OptionValue[]>(() => props.options ?? [])
+  const optionList = computed<OptionValue[]>(() => props.options ?? [])
+
+  // --- Option helpers ---
+
+  function getOptionLabel(option: OptionValue): string {
+    if (props.getOptionLabel) return props.getOptionLabel(option)
+    if (typeof option === 'object' && option !== null) {
+      const key = props.label ?? 'label'
+      return String((option as Record<string, unknown>)[key] ?? '')
+    }
+    return String(option)
+  }
+
+  function getOptionKey(option: OptionValue): string {
+    if (props.getOptionKey) return props.getOptionKey(option)
+    if (typeof option === 'object' && option !== null && 'id' in option) {
+      return String((option as Record<string, unknown>).id)
+    }
+    return JSON.stringify(option)
+  }
+
+  function isOptionSelected(option: OptionValue): boolean {
+    return selectedValue.value.some(
+      (selected) => getOptionKey(selected) === getOptionKey(option)
+    )
+  }
+
+  function isOptionSelectable(option: OptionValue): boolean {
+    return props.selectable ? props.selectable(option) : true
+  }
+
+  function isOptionHighlighted(index: number): boolean {
+    return typeAheadPointer.value === index
+  }
+
+  // --- Open state ---
+
+  function setOpen(value: boolean) {
+    open.value = value
+    emit(value ? 'open' : 'close')
+  }
+
+  function toggleOpen() {
+    setOpen(!open.value)
+  }
+
+  // --- Search ---
+
+  function setSearch(value: string) {
+    search.value = value
+  }
+
+  // --- Selection ---
+
+  function select(option: OptionValue) {
+    emit('option:selecting', option)
+    if (props.multiple) {
+      const current = Array.isArray(props.modelValue)
+        ? [...props.modelValue]
+        : []
+      current.push(option)
+      emit('update:modelValue', current)
+    } else {
+      emit('update:modelValue', option)
+    }
+    emit('option:selected', option)
+  }
+
+  function deselect(option: OptionValue) {
+    emit('option:deselecting', option)
+    const current = Array.isArray(props.modelValue)
+      ? [...props.modelValue]
+      : []
+    const filtered = current.filter(
+      (v) => getOptionKey(v) !== getOptionKey(option)
+    )
+    emit('update:modelValue', filtered)
+    emit('option:deselected', option)
+  }
+
+  function clearSelection() {
+    emit('update:modelValue', props.multiple ? [] : null)
+  }
+
+  // --- Stubs for later tasks ---
+
+  function typeAheadUp() {}
+  function typeAheadDown() {}
+  function typeAheadSelect() {}
+
+  function toggleLoading(value?: boolean) {
+    isLoading.value = value ?? !isLoading.value
+  }
+
+  return {
+    // State
+    open,
+    search,
+    selectedValue,
+    filteredOptions,
+    typeAheadPointer,
+    isLoading,
+    disabled,
+    multiple,
+    filterable,
+    noDrop,
+    clearable,
+    taggable,
+    placeholder,
+    isValueEmpty,
+    isSearching,
+    uid,
+
+    // Methods
+    select,
+    deselect,
+    clearSelection,
+    toggleOpen,
+    setOpen,
+    setSearch,
+    typeAheadUp,
+    typeAheadDown,
+    typeAheadSelect,
+    toggleLoading,
+    getOptionLabel,
+    getOptionKey,
+    isOptionSelected,
+    isOptionSelectable,
+    isOptionHighlighted,
+    optionList,
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-import VueSelect from './components/Select.vue'
-
-export default VueSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,19 @@
+// src/index.ts
+import Select from './components/Select.vue'
+
+// Headless primitives
+export { default as ComboBox } from './components/ComboBox/ComboBox.vue'
+export { default as ComboBoxInput } from './components/ComboBox/ComboBoxInput.vue'
+export { default as ComboBoxMenu } from './components/ComboBox/ComboBoxMenu.vue'
+export { default as ComboBoxOption } from './components/ComboBox/ComboBoxOption.vue'
+export { default as ComboBoxButton } from './components/ComboBox/ComboBoxButton.vue'
+export { default as ComboBoxClear } from './components/ComboBox/ComboBoxClear.vue'
+
+// Composable
+export { useComboBox } from './hooks/useComboBox'
+
+// Types
+export type { ComboBoxProps, ComboBoxContext, OptionValue, ModelValue } from './types'
+
+// Default export: the batteries-included component
+export default Select

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,8 +1,16 @@
 import type { InjectionKey } from 'vue'
-import type { ResolvedListBoxProps } from '@/types'
+import type { ComboBoxContext, ResolvedListBoxProps } from '@/types'
 
+export const ComboBoxKey: InjectionKey<ComboBoxContext> = Symbol('ComboBoxContext')
+
+/**
+ * @deprecated Use ComboBoxKey instead. Will be removed in a future release.
+ */
 export const ListBoxKey: InjectionKey<ResolvedListBoxProps> = Symbol(
   'ListBoxInjectionKey',
 )
 
+/**
+ * @deprecated Will be removed in a future release.
+ */
 export const ListBoxOptionInjectionKey = Symbol() as InjectionKey<string>

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,8 @@ export interface ComboBoxContext {
   isValueEmpty: ComputedRef<boolean>
   isSearching: ComputedRef<boolean>
   uid: ComputedRef<string>
+  deselectFromDropdown: ComputedRef<boolean>
+  autoscroll: ComputedRef<boolean>
 
   // Methods
   select: (option: OptionValue) => void

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,105 @@
-import { ComputedRef, PropType } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 
-export type VueSelectValue = PropType<unknown>
-export type VueSelectOption = PropType<unknown>
+/**
+ * A single option can be a string, number, or object.
+ */
+export type OptionValue = string | number | Record<string, unknown>
 
+/**
+ * The modelValue can be a single option, an array (multi-select), or null.
+ */
+export type ModelValue = OptionValue | OptionValue[] | null
+
+/**
+ * Props accepted by the ComboBox root component.
+ */
+export interface ComboBoxProps {
+  modelValue?: ModelValue
+  options?: OptionValue[]
+  multiple?: boolean
+  filterable?: boolean
+  taggable?: boolean
+  pushTags?: boolean
+  clearable?: boolean
+  closeOnSelect?: boolean
+  clearSearchOnSelect?: boolean
+  disabled?: boolean
+  open?: boolean
+  label?: string
+  reduce?: (option: OptionValue) => unknown
+  selectable?: (option: OptionValue) => boolean
+  getOptionLabel?: (option: OptionValue) => string
+  getOptionKey?: (option: OptionValue) => string
+  filter?: (options: OptionValue[], search: string) => OptionValue[]
+  filterBy?: (option: OptionValue, label: string, search: string) => boolean
+  createOption?: (search: string) => OptionValue
+  loading?: boolean
+  uid?: string
+  placeholder?: string
+  noDrop?: boolean
+  deselectFromDropdown?: boolean
+  autoscroll?: boolean
+}
+
+/**
+ * The resolved context provided to child components via inject.
+ */
+export interface ComboBoxContext {
+  // State (readonly)
+  open: Ref<boolean>
+  search: Ref<string>
+  selectedValue: ComputedRef<OptionValue[]>
+  filteredOptions: ComputedRef<OptionValue[]>
+  typeAheadPointer: Ref<number>
+  isLoading: Ref<boolean>
+  disabled: ComputedRef<boolean>
+  multiple: ComputedRef<boolean>
+  filterable: ComputedRef<boolean>
+  noDrop: ComputedRef<boolean>
+  clearable: ComputedRef<boolean>
+  taggable: ComputedRef<boolean>
+  placeholder: ComputedRef<string>
+  isValueEmpty: ComputedRef<boolean>
+  isSearching: ComputedRef<boolean>
+  uid: ComputedRef<string>
+
+  // Methods
+  select: (option: OptionValue) => void
+  deselect: (option: OptionValue) => void
+  clearSelection: () => void
+  toggleOpen: () => void
+  setOpen: (value: boolean) => void
+  setSearch: (value: string) => void
+  typeAheadUp: () => void
+  typeAheadDown: () => void
+  typeAheadSelect: () => void
+  toggleLoading: (value?: boolean) => void
+  getOptionLabel: (option: OptionValue) => string
+  getOptionKey: (option: OptionValue) => string
+  isOptionSelected: (option: OptionValue) => boolean
+  isOptionSelectable: (option: OptionValue) => boolean
+  isOptionHighlighted: (index: number) => boolean
+  optionList: ComputedRef<OptionValue[]>
+}
+
+/**
+ * @deprecated Use ComboBoxProps instead. Will be removed in a future release.
+ */
+export type VueSelectValue = unknown
+/**
+ * @deprecated Use ComboBoxProps instead. Will be removed in a future release.
+ */
+export type VueSelectOption = unknown
+/**
+ * @deprecated Use ComboBoxProps instead. Will be removed in a future release.
+ */
 export interface ListBoxProps {
   modelValue: VueSelectValue
   open?: boolean | undefined
 }
+/**
+ * @deprecated Use ComboBoxContext instead. Will be removed in a future release.
+ */
 export interface ResolvedListBoxProps extends Omit<ListBoxProps, 'open'> {
   open: boolean
   inputText: string

--- a/tests/unit/ComboBox/ComboBox.spec.ts
+++ b/tests/unit/ComboBox/ComboBox.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { inject, defineComponent, h } from 'vue'
+import ComboBox from '@/components/ComboBox/ComboBox.vue'
+import { ComboBoxKey } from '@/keys'
+
+// Helper component to inspect injected context
+const ContextReader = defineComponent({
+  setup() {
+    const ctx = inject(ComboBoxKey)!
+    return { ctx }
+  },
+  render() {
+    return h('div', `open:${this.ctx.open.value}`)
+  },
+})
+
+function mountComboBox(props = {}) {
+  return mount(ComboBox, {
+    props: { options: ['one', 'two', 'three'], ...props },
+    slots: { default: () => h(ContextReader) },
+  })
+}
+
+describe('ComboBox', () => {
+  it('provides ComboBoxContext to children', () => {
+    const wrapper = mountComboBox()
+    const reader = wrapper.findComponent(ContextReader)
+    expect(reader.vm.ctx).toBeDefined()
+    expect(reader.vm.ctx.open.value).toBe(false)
+  })
+
+  it('renders a root element with role=combobox', () => {
+    const wrapper = mountComboBox()
+    expect(wrapper.attributes('role')).toBe('combobox')
+  })
+
+  it('sets aria-expanded based on open state', () => {
+    const wrapper = mountComboBox()
+    expect(wrapper.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('emits update:modelValue when selection changes', () => {
+    const wrapper = mountComboBox()
+    const reader = wrapper.findComponent(ContextReader)
+    reader.vm.ctx.select('one')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['one'])
+  })
+
+  it('renders slot content', () => {
+    const wrapper = mountComboBox()
+    expect(wrapper.text()).toContain('open:false')
+  })
+
+  it('passes all props through to useComboBox', () => {
+    const wrapper = mountComboBox({ multiple: true, placeholder: 'Pick...' })
+    const reader = wrapper.findComponent(ContextReader)
+    expect(reader.vm.ctx.multiple.value).toBe(true)
+    expect(reader.vm.ctx.placeholder.value).toBe('Pick...')
+  })
+})

--- a/tests/unit/ComboBox/ComboBox.spec.ts
+++ b/tests/unit/ComboBox/ComboBox.spec.ts
@@ -30,14 +30,14 @@ describe('ComboBox', () => {
     expect(reader.vm.ctx.open.value).toBe(false)
   })
 
-  it('renders a root element with role=combobox', () => {
+  it('does not have role=combobox on wrapper (role is on input)', () => {
     const wrapper = mountComboBox()
-    expect(wrapper.attributes('role')).toBe('combobox')
+    expect(wrapper.attributes('role')).toBeUndefined()
   })
 
-  it('sets aria-expanded based on open state', () => {
+  it('does not have aria-expanded on wrapper (managed by input)', () => {
     const wrapper = mountComboBox()
-    expect(wrapper.attributes('aria-expanded')).toBe('false')
+    expect(wrapper.attributes('aria-expanded')).toBeUndefined()
   })
 
   it('emits update:modelValue when selection changes', () => {

--- a/tests/unit/ComboBox/ComboBoxButton.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxButton.spec.ts
@@ -23,6 +23,8 @@ function createMockContext(overrides = {}): ComboBoxContext {
     isValueEmpty: computed(() => true),
     isSearching: computed(() => false),
     uid: computed(() => 'test'),
+    deselectFromDropdown: computed(() => false),
+    autoscroll: computed(() => true),
     select: vi.fn(),
     deselect: vi.fn(),
     clearSelection: vi.fn(),

--- a/tests/unit/ComboBox/ComboBoxButton.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxButton.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import ComboBoxButton from '@/components/ComboBox/ComboBoxButton.vue'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxContext, OptionValue } from '@/types'
+
+function createMockContext(overrides = {}): ComboBoxContext {
+  return {
+    open: ref(false),
+    search: ref(''),
+    selectedValue: computed(() => []),
+    filteredOptions: computed(() => []),
+    typeAheadPointer: ref(-1),
+    isLoading: ref(false),
+    disabled: computed(() => false),
+    multiple: computed(() => false),
+    filterable: computed(() => true),
+    noDrop: computed(() => false),
+    clearable: computed(() => true),
+    taggable: computed(() => false),
+    placeholder: computed(() => ''),
+    isValueEmpty: computed(() => true),
+    isSearching: computed(() => false),
+    uid: computed(() => 'test'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleOpen: vi.fn(),
+    setOpen: vi.fn(),
+    setSearch: vi.fn(),
+    typeAheadUp: vi.fn(),
+    typeAheadDown: vi.fn(),
+    typeAheadSelect: vi.fn(),
+    toggleLoading: vi.fn(),
+    getOptionLabel: (opt: OptionValue) => String(opt),
+    getOptionKey: (opt: OptionValue) => JSON.stringify(opt),
+    isOptionSelected: () => false,
+    isOptionSelectable: () => true,
+    isOptionHighlighted: () => false,
+    optionList: computed(() => []),
+    ...overrides,
+  }
+}
+
+function mountButton(ctxOverrides = {}) {
+  const ctx = createMockContext(ctxOverrides)
+  const wrapper = mount(ComboBoxButton, {
+    global: {
+      provide: { [ComboBoxKey as symbol]: ctx },
+    },
+    slots: { default: 'Toggle' },
+  })
+  return { wrapper, ctx }
+}
+
+describe('ComboBoxButton', () => {
+  it('has aria-haspopup="listbox"', () => {
+    const { wrapper } = mountButton()
+    expect(wrapper.attributes('aria-haspopup')).toBe('listbox')
+  })
+
+  it('has aria-expanded reflecting open state', () => {
+    const { wrapper } = mountButton({ open: ref(true) })
+    expect(wrapper.attributes('aria-expanded')).toBe('true')
+  })
+
+  it('has aria-controls pointing to listbox', () => {
+    const { wrapper } = mountButton()
+    expect(wrapper.attributes('aria-controls')).toBe('vs-test-listbox')
+  })
+
+  it('click calls toggleOpen', async () => {
+    const { wrapper, ctx } = mountButton()
+    await wrapper.trigger('click')
+    expect(ctx.toggleOpen).toHaveBeenCalled()
+  })
+
+  it('is disabled when context is disabled', () => {
+    const { wrapper } = mountButton({ disabled: computed(() => true) })
+    expect(wrapper.attributes('disabled')).toBeDefined()
+  })
+
+  it('renders slot content', () => {
+    const { wrapper } = mountButton()
+    expect(wrapper.text()).toBe('Toggle')
+  })
+})

--- a/tests/unit/ComboBox/ComboBoxClear.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxClear.spec.ts
@@ -23,6 +23,8 @@ function createMockContext(overrides = {}): ComboBoxContext {
     isValueEmpty: computed(() => true),
     isSearching: computed(() => false),
     uid: computed(() => 'test'),
+    deselectFromDropdown: computed(() => false),
+    autoscroll: computed(() => true),
     select: vi.fn(),
     deselect: vi.fn(),
     clearSelection: vi.fn(),

--- a/tests/unit/ComboBox/ComboBoxClear.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxClear.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import ComboBoxClear from '@/components/ComboBox/ComboBoxClear.vue'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxContext, OptionValue } from '@/types'
+
+function createMockContext(overrides = {}): ComboBoxContext {
+  return {
+    open: ref(false),
+    search: ref(''),
+    selectedValue: computed(() => []),
+    filteredOptions: computed(() => []),
+    typeAheadPointer: ref(-1),
+    isLoading: ref(false),
+    disabled: computed(() => false),
+    multiple: computed(() => false),
+    filterable: computed(() => true),
+    noDrop: computed(() => false),
+    clearable: computed(() => true),
+    taggable: computed(() => false),
+    placeholder: computed(() => ''),
+    isValueEmpty: computed(() => true),
+    isSearching: computed(() => false),
+    uid: computed(() => 'test'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleOpen: vi.fn(),
+    setOpen: vi.fn(),
+    setSearch: vi.fn(),
+    typeAheadUp: vi.fn(),
+    typeAheadDown: vi.fn(),
+    typeAheadSelect: vi.fn(),
+    toggleLoading: vi.fn(),
+    getOptionLabel: (opt: OptionValue) => String(opt),
+    getOptionKey: (opt: OptionValue) => JSON.stringify(opt),
+    isOptionSelected: () => false,
+    isOptionSelectable: () => true,
+    isOptionHighlighted: () => false,
+    optionList: computed(() => []),
+    ...overrides,
+  }
+}
+
+function mountClear(ctxOverrides = {}) {
+  const ctx = createMockContext(ctxOverrides)
+  const wrapper = mount(ComboBoxClear, {
+    global: {
+      provide: { [ComboBoxKey as symbol]: ctx },
+    },
+    slots: { default: 'x' },
+  })
+  return { wrapper, ctx }
+}
+
+describe('ComboBoxClear', () => {
+  it('is not visible when value is empty', () => {
+    const { wrapper } = mountClear({ isValueEmpty: computed(() => true) })
+    expect(wrapper.isVisible()).toBe(false)
+  })
+
+  it('is not visible when clearable is false', () => {
+    const { wrapper } = mountClear({
+      isValueEmpty: computed(() => false),
+      clearable: computed(() => false),
+    })
+    expect(wrapper.isVisible()).toBe(false)
+  })
+
+  it('is visible when value is not empty and clearable', () => {
+    const { wrapper } = mountClear({
+      isValueEmpty: computed(() => false),
+      clearable: computed(() => true),
+    })
+    expect(wrapper.isVisible()).toBe(true)
+  })
+
+  it('click calls clearSelection', async () => {
+    const { wrapper, ctx } = mountClear({
+      isValueEmpty: computed(() => false),
+    })
+    await wrapper.trigger('click')
+    expect(ctx.clearSelection).toHaveBeenCalled()
+  })
+
+  it('renders slot content', () => {
+    const { wrapper } = mountClear({ isValueEmpty: computed(() => false) })
+    expect(wrapper.text()).toBe('x')
+  })
+
+  it('has aria-label', () => {
+    const { wrapper } = mountClear({ isValueEmpty: computed(() => false) })
+    expect(wrapper.attributes('aria-label')).toBe('Clear selection')
+  })
+})

--- a/tests/unit/ComboBox/ComboBoxInput.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxInput.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { defineComponent, h, provide, ref, computed } from 'vue'
+import { ref, computed } from 'vue'
 import ComboBoxInput from '@/components/ComboBox/ComboBoxInput.vue'
 import { ComboBoxKey } from '@/keys'
 import type { ComboBoxContext, OptionValue } from '@/types'

--- a/tests/unit/ComboBox/ComboBoxInput.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxInput.spec.ts
@@ -23,6 +23,8 @@ function createMockContext(overrides = {}): ComboBoxContext {
     isValueEmpty: computed(() => true),
     isSearching: computed(() => false),
     uid: computed(() => 'test'),
+    deselectFromDropdown: computed(() => false),
+    autoscroll: computed(() => true),
     select: vi.fn(),
     deselect: vi.fn(),
     clearSelection: vi.fn(),
@@ -64,7 +66,9 @@ describe('ComboBoxInput', () => {
   it('has correct ARIA attributes', () => {
     const { wrapper } = mountInput()
     const input = wrapper.find('input')
+    expect(input.attributes('role')).toBe('combobox')
     expect(input.attributes('aria-autocomplete')).toBe('list')
+    expect(input.attributes('aria-expanded')).toBe('false')
     expect(input.attributes('aria-controls')).toBe('vs-test-listbox')
     expect(input.attributes('autocomplete')).toBe('off')
   })

--- a/tests/unit/ComboBox/ComboBoxInput.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxInput.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, provide, ref, computed } from 'vue'
+import ComboBoxInput from '@/components/ComboBox/ComboBoxInput.vue'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxContext, OptionValue } from '@/types'
+
+function createMockContext(overrides = {}): ComboBoxContext {
+  return {
+    open: ref(false),
+    search: ref(''),
+    selectedValue: computed(() => []),
+    filteredOptions: computed(() => []),
+    typeAheadPointer: ref(-1),
+    isLoading: ref(false),
+    disabled: computed(() => false),
+    multiple: computed(() => false),
+    filterable: computed(() => true),
+    noDrop: computed(() => false),
+    clearable: computed(() => true),
+    taggable: computed(() => false),
+    placeholder: computed(() => ''),
+    isValueEmpty: computed(() => true),
+    isSearching: computed(() => false),
+    uid: computed(() => 'test'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleOpen: vi.fn(),
+    setOpen: vi.fn(),
+    setSearch: vi.fn(),
+    typeAheadUp: vi.fn(),
+    typeAheadDown: vi.fn(),
+    typeAheadSelect: vi.fn(),
+    toggleLoading: vi.fn(),
+    getOptionLabel: (opt: OptionValue) => String(opt),
+    getOptionKey: (opt: OptionValue) => JSON.stringify(opt),
+    isOptionSelected: () => false,
+    isOptionSelectable: () => true,
+    isOptionHighlighted: () => false,
+    optionList: computed(() => []),
+    ...overrides,
+  }
+}
+
+function mountInput(ctxOverrides = {}) {
+  const ctx = createMockContext(ctxOverrides)
+  const wrapper = mount(ComboBoxInput, {
+    global: {
+      provide: { [ComboBoxKey as symbol]: ctx },
+    },
+  })
+  return { wrapper, ctx }
+}
+
+describe('ComboBoxInput', () => {
+  it('renders an input with type="search"', () => {
+    const { wrapper } = mountInput()
+    const input = wrapper.find('input')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('type')).toBe('search')
+  })
+
+  it('has correct ARIA attributes', () => {
+    const { wrapper } = mountInput()
+    const input = wrapper.find('input')
+    expect(input.attributes('aria-autocomplete')).toBe('list')
+    expect(input.attributes('aria-controls')).toBe('vs-test-listbox')
+    expect(input.attributes('autocomplete')).toBe('off')
+  })
+
+  it('sets aria-activedescendant when pointer is active', () => {
+    const { wrapper } = mountInput({ typeAheadPointer: ref(2) })
+    const input = wrapper.find('input')
+    expect(input.attributes('aria-activedescendant')).toBe('vs-test-option-2')
+  })
+
+  it('does not set aria-activedescendant when pointer is -1', () => {
+    const { wrapper } = mountInput()
+    const input = wrapper.find('input')
+    expect(input.attributes('aria-activedescendant')).toBeUndefined()
+  })
+
+  it('calls setSearch on input', async () => {
+    const { wrapper, ctx } = mountInput()
+    const input = wrapper.find('input')
+    await input.setValue('hello')
+    expect(ctx.setSearch).toHaveBeenCalledWith('hello')
+  })
+
+  it('ArrowDown calls typeAheadDown and opens dropdown', async () => {
+    const { wrapper, ctx } = mountInput()
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    expect(ctx.typeAheadDown).toHaveBeenCalled()
+    expect(ctx.setOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('ArrowUp calls typeAheadUp', async () => {
+    const { wrapper, ctx } = mountInput()
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowUp' })
+    expect(ctx.typeAheadUp).toHaveBeenCalled()
+  })
+
+  it('Enter calls typeAheadSelect when open', async () => {
+    const { wrapper, ctx } = mountInput({ open: ref(true) })
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    expect(ctx.typeAheadSelect).toHaveBeenCalled()
+  })
+
+  it('Escape clears search when searching', async () => {
+    const search = ref('hello')
+    const { wrapper, ctx } = mountInput({
+      search,
+      isSearching: computed(() => search.value.length > 0),
+    })
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    expect(ctx.setSearch).toHaveBeenCalledWith('')
+  })
+
+  it('Escape closes dropdown when not searching', async () => {
+    const { wrapper, ctx } = mountInput({ open: ref(true) })
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    expect(ctx.setOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('Backspace deselects last value when search empty and multiple', async () => {
+    const lastOption = 'two'
+    const { wrapper, ctx } = mountInput({
+      multiple: computed(() => true),
+      isValueEmpty: computed(() => false),
+      selectedValue: computed(() => ['one', lastOption]),
+    })
+    await wrapper.find('input').trigger('keydown', { key: 'Backspace' })
+    expect(ctx.deselect).toHaveBeenCalledWith(lastOption)
+  })
+
+  it('focus opens the dropdown', async () => {
+    const { wrapper, ctx } = mountInput()
+    await wrapper.find('input').trigger('focus')
+    expect(ctx.setOpen).toHaveBeenCalledWith(true)
+  })
+
+  it('is disabled when context is disabled', () => {
+    const { wrapper } = mountInput({ disabled: computed(() => true) })
+    expect(wrapper.find('input').attributes('disabled')).toBeDefined()
+  })
+})

--- a/tests/unit/ComboBox/ComboBoxMenu.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxMenu.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { ref, computed, h } from 'vue'
+import { ref, computed } from 'vue'
 import ComboBoxMenu from '@/components/ComboBox/ComboBoxMenu.vue'
 import { ComboBoxKey } from '@/keys'
 import type { ComboBoxContext, OptionValue } from '@/types'

--- a/tests/unit/ComboBox/ComboBoxMenu.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxMenu.spec.ts
@@ -23,6 +23,8 @@ function createMockContext(overrides = {}): ComboBoxContext {
     isValueEmpty: computed(() => true),
     isSearching: computed(() => false),
     uid: computed(() => 'test'),
+    deselectFromDropdown: computed(() => false),
+    autoscroll: computed(() => true),
     select: vi.fn(),
     deselect: vi.fn(),
     clearSelection: vi.fn(),

--- a/tests/unit/ComboBox/ComboBoxMenu.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxMenu.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed, h } from 'vue'
+import ComboBoxMenu from '@/components/ComboBox/ComboBoxMenu.vue'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxContext, OptionValue } from '@/types'
+
+function createMockContext(overrides = {}): ComboBoxContext {
+  return {
+    open: ref(false),
+    search: ref(''),
+    selectedValue: computed(() => []),
+    filteredOptions: computed(() => []),
+    typeAheadPointer: ref(-1),
+    isLoading: ref(false),
+    disabled: computed(() => false),
+    multiple: computed(() => false),
+    filterable: computed(() => true),
+    noDrop: computed(() => false),
+    clearable: computed(() => true),
+    taggable: computed(() => false),
+    placeholder: computed(() => ''),
+    isValueEmpty: computed(() => true),
+    isSearching: computed(() => false),
+    uid: computed(() => 'test'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleOpen: vi.fn(),
+    setOpen: vi.fn(),
+    setSearch: vi.fn(),
+    typeAheadUp: vi.fn(),
+    typeAheadDown: vi.fn(),
+    typeAheadSelect: vi.fn(),
+    toggleLoading: vi.fn(),
+    getOptionLabel: (opt: OptionValue) => String(opt),
+    getOptionKey: (opt: OptionValue) => JSON.stringify(opt),
+    isOptionSelected: () => false,
+    isOptionSelectable: () => true,
+    isOptionHighlighted: () => false,
+    optionList: computed(() => []),
+    ...overrides,
+  }
+}
+
+function mountMenu(ctxOverrides = {}, slotContent?: string) {
+  const ctx = createMockContext(ctxOverrides)
+  const wrapper = mount(ComboBoxMenu, {
+    global: {
+      provide: { [ComboBoxKey as symbol]: ctx },
+    },
+    slots: { default: slotContent ?? 'Menu content' },
+  })
+  return { wrapper, ctx }
+}
+
+describe('ComboBoxMenu', () => {
+  it('has role="listbox"', () => {
+    const { wrapper } = mountMenu({ open: ref(true) })
+    expect(wrapper.attributes('role')).toBe('listbox')
+  })
+
+  it('has correct id', () => {
+    const { wrapper } = mountMenu({ open: ref(true) })
+    expect(wrapper.attributes('id')).toBe('vs-test-listbox')
+  })
+
+  it('has tabindex="-1"', () => {
+    const { wrapper } = mountMenu({ open: ref(true) })
+    expect(wrapper.attributes('tabindex')).toBe('-1')
+  })
+
+  it('is visible when open is true', () => {
+    const { wrapper } = mountMenu({ open: ref(true) })
+    expect(wrapper.isVisible()).toBe(true)
+  })
+
+  it('is hidden when open is false', () => {
+    const { wrapper } = mountMenu({ open: ref(false) })
+    expect(wrapper.isVisible()).toBe(false)
+  })
+
+  it('is hidden when noDrop is true even if open', () => {
+    const { wrapper } = mountMenu({ open: ref(true), noDrop: computed(() => true) })
+    expect(wrapper.isVisible()).toBe(false)
+  })
+
+  it('renders slot content', () => {
+    const { wrapper } = mountMenu({ open: ref(true) }, 'Test options')
+    expect(wrapper.text()).toContain('Test options')
+  })
+})

--- a/tests/unit/ComboBox/ComboBoxOption.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxOption.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import ComboBoxOption from '@/components/ComboBox/ComboBoxOption.vue'
+import { ComboBoxKey } from '@/keys'
+import type { ComboBoxContext, OptionValue } from '@/types'
+
+function createMockContext(overrides = {}): ComboBoxContext {
+  return {
+    open: ref(false),
+    search: ref(''),
+    selectedValue: computed(() => []),
+    filteredOptions: computed(() => []),
+    typeAheadPointer: ref(-1),
+    isLoading: ref(false),
+    disabled: computed(() => false),
+    multiple: computed(() => false),
+    filterable: computed(() => true),
+    noDrop: computed(() => false),
+    clearable: computed(() => true),
+    taggable: computed(() => false),
+    placeholder: computed(() => ''),
+    isValueEmpty: computed(() => true),
+    isSearching: computed(() => false),
+    uid: computed(() => 'test'),
+    select: vi.fn(),
+    deselect: vi.fn(),
+    clearSelection: vi.fn(),
+    toggleOpen: vi.fn(),
+    setOpen: vi.fn(),
+    setSearch: vi.fn(),
+    typeAheadUp: vi.fn(),
+    typeAheadDown: vi.fn(),
+    typeAheadSelect: vi.fn(),
+    toggleLoading: vi.fn(),
+    getOptionLabel: (opt: OptionValue) => String(opt),
+    getOptionKey: (opt: OptionValue) => JSON.stringify(opt),
+    isOptionSelected: () => false,
+    isOptionSelectable: () => true,
+    isOptionHighlighted: () => false,
+    optionList: computed(() => []),
+    ...overrides,
+  }
+}
+
+function mountOption(props = {}, ctxOverrides = {}) {
+  const ctx = createMockContext(ctxOverrides)
+  const wrapper = mount(ComboBoxOption, {
+    props: { value: 'test', index: 0, ...props },
+    global: {
+      provide: { [ComboBoxKey as symbol]: ctx },
+    },
+    slots: {
+      default: (slotProps: any) =>
+        `selected:${slotProps.isSelected},highlighted:${slotProps.isHighlighted},disabled:${slotProps.isDisabled}`,
+    },
+  })
+  return { wrapper, ctx }
+}
+
+describe('ComboBoxOption', () => {
+  it('has role="option"', () => {
+    const { wrapper } = mountOption()
+    expect(wrapper.attributes('role')).toBe('option')
+  })
+
+  it('has correct id', () => {
+    const { wrapper } = mountOption({ index: 3 })
+    expect(wrapper.attributes('id')).toBe('vs-test-option-3')
+  })
+
+  it('sets aria-selected when selected', () => {
+    const { wrapper } = mountOption({}, { isOptionSelected: () => true })
+    expect(wrapper.attributes('aria-selected')).toBe('true')
+  })
+
+  it('does not set aria-selected when not selected', () => {
+    const { wrapper } = mountOption()
+    expect(wrapper.attributes('aria-selected')).toBeUndefined()
+  })
+
+  it('sets aria-disabled when not selectable', () => {
+    const { wrapper } = mountOption({}, { isOptionSelectable: () => false })
+    expect(wrapper.attributes('aria-disabled')).toBe('true')
+  })
+
+  it('click calls select when not selected', async () => {
+    const { wrapper, ctx } = mountOption()
+    await wrapper.trigger('click')
+    expect(ctx.select).toHaveBeenCalledWith('test')
+  })
+
+  it('click calls deselect when already selected', async () => {
+    const { wrapper, ctx } = mountOption({}, { isOptionSelected: () => true })
+    await wrapper.trigger('click')
+    expect(ctx.deselect).toHaveBeenCalledWith('test')
+  })
+
+  it('click does nothing when disabled', async () => {
+    const { wrapper, ctx } = mountOption({}, { isOptionSelectable: () => false })
+    await wrapper.trigger('click')
+    expect(ctx.select).not.toHaveBeenCalled()
+    expect(ctx.deselect).not.toHaveBeenCalled()
+  })
+
+  it('mouseover updates typeAheadPointer', async () => {
+    const pointer = ref(-1)
+    const { wrapper } = mountOption({ index: 2 }, { typeAheadPointer: pointer })
+    await wrapper.trigger('mouseover')
+    expect(pointer.value).toBe(2)
+  })
+
+  it('exposes isSelected, isHighlighted, isDisabled via slot', () => {
+    const { wrapper } = mountOption({}, {
+      isOptionSelected: () => true,
+      isOptionHighlighted: (i: number) => i === 0,
+    })
+    expect(wrapper.text()).toContain('selected:true')
+    expect(wrapper.text()).toContain('highlighted:true')
+    expect(wrapper.text()).toContain('disabled:false')
+  })
+})

--- a/tests/unit/ComboBox/ComboBoxOption.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxOption.spec.ts
@@ -53,7 +53,7 @@ function mountOption(props = {}, ctxOverrides = {}) {
       provide: { [ComboBoxKey as symbol]: ctx },
     },
     slots: {
-      default: (slotProps: any) =>
+      default: (slotProps: { isSelected: boolean; isHighlighted: boolean; isDisabled: boolean }) =>
         `selected:${slotProps.isSelected},highlighted:${slotProps.isHighlighted},disabled:${slotProps.isDisabled}`,
     },
   })

--- a/tests/unit/ComboBox/ComboBoxOption.spec.ts
+++ b/tests/unit/ComboBox/ComboBoxOption.spec.ts
@@ -23,6 +23,8 @@ function createMockContext(overrides = {}): ComboBoxContext {
     isValueEmpty: computed(() => true),
     isSearching: computed(() => false),
     uid: computed(() => 'test'),
+    deselectFromDropdown: computed(() => false),
+    autoscroll: computed(() => true),
     select: vi.fn(),
     deselect: vi.fn(),
     clearSelection: vi.fn(),
@@ -74,9 +76,9 @@ describe('ComboBoxOption', () => {
     expect(wrapper.attributes('aria-selected')).toBe('true')
   })
 
-  it('does not set aria-selected when not selected', () => {
+  it('sets aria-selected="false" when not selected', () => {
     const { wrapper } = mountOption()
-    expect(wrapper.attributes('aria-selected')).toBeUndefined()
+    expect(wrapper.attributes('aria-selected')).toBe('false')
   })
 
   it('sets aria-disabled when not selectable', () => {
@@ -90,10 +92,23 @@ describe('ComboBoxOption', () => {
     expect(ctx.select).toHaveBeenCalledWith('test')
   })
 
-  it('click calls deselect when already selected', async () => {
-    const { wrapper, ctx } = mountOption({}, { isOptionSelected: () => true })
+  it('click calls deselect when already selected and deselectFromDropdown is true', async () => {
+    const { wrapper, ctx } = mountOption({}, {
+      isOptionSelected: () => true,
+      deselectFromDropdown: computed(() => true),
+    })
     await wrapper.trigger('click')
     expect(ctx.deselect).toHaveBeenCalledWith('test')
+  })
+
+  it('click does nothing when already selected and deselectFromDropdown is false', async () => {
+    const { wrapper, ctx } = mountOption({}, {
+      isOptionSelected: () => true,
+      deselectFromDropdown: computed(() => false),
+    })
+    await wrapper.trigger('click')
+    expect(ctx.select).not.toHaveBeenCalled()
+    expect(ctx.deselect).not.toHaveBeenCalled()
   })
 
   it('click does nothing when disabled', async () => {

--- a/tests/unit/ComboBox/integration.spec.ts
+++ b/tests/unit/ComboBox/integration.spec.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h, inject, nextTick } from 'vue'
+import {
+  ComboBox,
+  ComboBoxInput,
+  ComboBoxMenu,
+  ComboBoxOption,
+  ComboBoxButton,
+  ComboBoxClear,
+} from '@/index'
+import { ComboBoxKey } from '@/keys'
+
+/**
+ * A helper component that injects ComboBoxContext and renders
+ * filteredOptions as ComboBoxOption children inside ComboBoxMenu.
+ * This mirrors real-world usage where the consumer reads from the
+ * context to know which options to display after filtering.
+ */
+const FilteredOptionList = defineComponent({
+  setup() {
+    const ctx = inject(ComboBoxKey)!
+    return { ctx }
+  },
+  render() {
+    return this.ctx.filteredOptions.value.map((opt: any, i: number) =>
+      h(
+        ComboBoxOption,
+        { value: opt, index: i, key: this.ctx.getOptionKey(opt) },
+        {
+          default: ({
+            isSelected,
+            isHighlighted,
+          }: {
+            isSelected: boolean
+            isHighlighted: boolean
+          }) =>
+            h(
+              'span',
+              {
+                class: {
+                  selected: isSelected,
+                  highlighted: isHighlighted,
+                },
+              },
+              String(opt)
+            ),
+        }
+      )
+    )
+  },
+})
+
+const TestSelect = defineComponent({
+  props: {
+    options: { type: Array, default: () => [] },
+    modelValue: { type: [String, Number, Object, Array], default: undefined },
+    multiple: { type: Boolean, default: false },
+    taggable: { type: Boolean, default: false },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () =>
+      h(
+        ComboBox,
+        {
+          ...props,
+          'onUpdate:modelValue': (v: unknown) => emit('update:modelValue', v),
+        },
+        {
+          default: () => [
+            h(ComboBoxInput),
+            h(ComboBoxButton, null, { default: () => 'Toggle' }),
+            h(ComboBoxClear, null, { default: () => 'Clear' }),
+            h(ComboBoxMenu, null, {
+              default: () => h(FilteredOptionList),
+            }),
+          ],
+        }
+      )
+  },
+})
+
+/** Wait for all pending Vue reactivity and DOM updates. */
+async function waitForUpdate() {
+  await nextTick()
+  await nextTick()
+}
+
+/**
+ * Checks whether the listbox menu is showing. We rely on the inline
+ * style.display set by v-show because jsdom's getComputedStyle does
+ * not propagate inline styles, which causes vue-test-utils' isVisible()
+ * to give false positives in deeply-nested component trees.
+ */
+function isListboxVisible(wrapper: ReturnType<typeof mount>): boolean {
+  const el = wrapper.find('[role="listbox"]').element as HTMLElement
+  return el.style.display !== 'none'
+}
+
+describe('ComboBox integration', () => {
+  it('full selection flow: open, navigate, select', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'] },
+    })
+
+    // Focus input to open
+    await wrapper.find('input').trigger('focus')
+    await waitForUpdate()
+    expect(isListboxVisible(wrapper)).toBe(true)
+
+    // Arrow down twice to highlight 'two'
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    await wrapper.find('input').trigger('keydown', { key: 'ArrowDown' })
+    await waitForUpdate()
+    expect(wrapper.find('.highlighted').text()).toBe('two')
+
+    // Enter to select
+    await wrapper.find('input').trigger('keydown', { key: 'Enter' })
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['two'])
+  })
+
+  it('multi-select flow', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'], multiple: true, modelValue: [] },
+    })
+
+    await wrapper.find('input').trigger('focus')
+    await waitForUpdate()
+
+    // Click 'one'
+    await wrapper.findAll('[role="option"]')[0].trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([['one']])
+  })
+
+  it('filtering flow', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'] },
+    })
+
+    await wrapper.find('input').trigger('focus')
+    await waitForUpdate()
+
+    await wrapper.find('input').setValue('tw')
+    await waitForUpdate()
+
+    const options = wrapper.findAll('[role="option"]')
+    expect(options).toHaveLength(1)
+    expect(options[0].text()).toBe('two')
+  })
+
+  it('escape closes dropdown', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'] },
+    })
+
+    await wrapper.find('input').trigger('focus')
+    await waitForUpdate()
+    expect(isListboxVisible(wrapper)).toBe(true)
+
+    await wrapper.find('input').trigger('keydown', { key: 'Escape' })
+    await waitForUpdate()
+    expect(isListboxVisible(wrapper)).toBe(false)
+  })
+
+  it('toggle button opens and closes dropdown', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'] },
+    })
+
+    await wrapper.find('button').trigger('click')
+    await waitForUpdate()
+    expect(isListboxVisible(wrapper)).toBe(true)
+
+    await wrapper.find('button').trigger('click')
+    await waitForUpdate()
+    expect(isListboxVisible(wrapper)).toBe(false)
+  })
+
+  it('clicking an option selects it', async () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two', 'three'] },
+    })
+
+    await wrapper.find('input').trigger('focus')
+    await waitForUpdate()
+    await wrapper.findAll('[role="option"]')[1].trigger('click')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['two'])
+  })
+
+  it('ARIA attributes are properly connected', () => {
+    const wrapper = mount(TestSelect, {
+      props: { options: ['one', 'two'] },
+    })
+
+    const combobox = wrapper.find('[role="combobox"]')
+    const listbox = wrapper.find('[role="listbox"]')
+    const options = wrapper.findAll('[role="option"]')
+
+    expect(combobox.exists()).toBe(true)
+    expect(listbox.exists()).toBe(true)
+    expect(options).toHaveLength(2)
+
+    // The combobox owns the listbox
+    expect(combobox.attributes('aria-owns')).toBe(listbox.attributes('id'))
+  })
+})

--- a/tests/unit/ComboBox/integration.spec.ts
+++ b/tests/unit/ComboBox/integration.spec.ts
@@ -10,6 +10,7 @@ import {
   ComboBoxClear,
 } from '@/index'
 import { ComboBoxKey } from '@/keys'
+import type { OptionValue } from '@/types'
 
 /**
  * A helper component that injects ComboBoxContext and renders
@@ -23,7 +24,7 @@ const FilteredOptionList = defineComponent({
     return { ctx }
   },
   render() {
-    return this.ctx.filteredOptions.value.map((opt: any, i: number) =>
+    return this.ctx.filteredOptions.value.map((opt: OptionValue, i: number) =>
       h(
         ComboBoxOption,
         { value: opt, index: i, key: this.ctx.getOptionKey(opt) },

--- a/tests/unit/ComboBox/integration.spec.ts
+++ b/tests/unit/ComboBox/integration.spec.ts
@@ -201,7 +201,7 @@ describe('ComboBox integration', () => {
     expect(listbox.exists()).toBe(true)
     expect(options).toHaveLength(2)
 
-    // The combobox owns the listbox
-    expect(combobox.attributes('aria-owns')).toBe(listbox.attributes('id'))
+    // The combobox (input) controls the listbox
+    expect(combobox.attributes('aria-controls')).toBe(listbox.attributes('id'))
   })
 })

--- a/tests/unit/hooks/useClickAway.spec.ts
+++ b/tests/unit/hooks/useClickAway.spec.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useClickAway } from '@/hooks/useClickAway'
+
+describe('useClickAway', () => {
+  let el: HTMLDivElement
+
+  beforeEach(() => {
+    el = document.createElement('div')
+    document.body.appendChild(el)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(el)
+  })
+
+  it('calls callback when clicking outside the element', async () => {
+    const callback = vi.fn()
+    const { addClickAwayListener } = useClickAway(callback)
+    addClickAwayListener(el)
+
+    document.body.click()
+    expect(callback).toHaveBeenCalledOnce()
+  })
+
+  it('does not call callback when clicking inside the element', () => {
+    const callback = vi.fn()
+    const { addClickAwayListener } = useClickAway(callback)
+    addClickAwayListener(el)
+
+    el.click()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('stops listening after removeClickAwayListener is called', () => {
+    const callback = vi.fn()
+    const { addClickAwayListener, removeClickAwayListener } = useClickAway(callback)
+    addClickAwayListener(el)
+    removeClickAwayListener(el)
+
+    document.body.click()
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when removing listener before adding', () => {
+    const callback = vi.fn()
+    const { removeClickAwayListener } = useClickAway(callback)
+    expect(() => removeClickAwayListener(el)).not.toThrow()
+  })
+})

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -367,4 +367,60 @@ describe('useComboBox', () => {
     })
   })
 
+  describe('tagging', () => {
+    it('select creates a new option from search text when taggable', () => {
+      const { select, setSearch, emit } = createComboBox({
+        options: ['one', 'two'],
+        taggable: true,
+      })
+      setSearch('new-tag')
+      select('new-tag')
+      expect(emit).toHaveBeenCalledWith('option:created', 'new-tag')
+      expect(emit).toHaveBeenCalledWith('update:modelValue', 'new-tag')
+    })
+
+    it('pushTags adds created tag to optionList', () => {
+      const { select, setSearch, optionList } = createComboBox({
+        options: ['one', 'two'],
+        taggable: true,
+        pushTags: true,
+      })
+      setSearch('new-tag')
+      select('new-tag')
+      expect(optionList.value).toContain('new-tag')
+    })
+
+    it('uses custom createOption when provided', () => {
+      const { select, setSearch, emit } = createComboBox({
+        options: [],
+        taggable: true,
+        label: 'label',
+        createOption: (search: string) => ({ label: search, custom: true }),
+      })
+      setSearch('new')
+      select({ label: 'new', custom: true })
+      expect(emit).toHaveBeenCalledWith('option:created', { label: 'new', custom: true })
+    })
+  })
+
+  describe('loading', () => {
+    it('isLoading reflects the loading prop', () => {
+      const { isLoading } = createComboBox({ loading: true })
+      expect(isLoading.value).toBe(true)
+    })
+
+    it('toggleLoading flips the internal loading state', () => {
+      const { isLoading, toggleLoading } = createComboBox()
+      expect(isLoading.value).toBe(false)
+      toggleLoading(true)
+      expect(isLoading.value).toBe(true)
+    })
+
+    it('emits search event when search changes', () => {
+      const { setSearch, emit } = createComboBox()
+      setSearch('hello')
+      expect(emit).toHaveBeenCalledWith('search', 'hello', expect.any(Function))
+    })
+  })
+
 })

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -303,4 +303,68 @@ describe('useComboBox', () => {
       expect(isOptionHighlighted(1)).toBe(false)
     })
   })
+
+  describe('reduce', () => {
+    it('emits the reduced value on select', () => {
+      const { select, emit } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }],
+        reduce: (opt: any) => opt.code,
+      })
+      select({ label: 'Canada', code: 'CA' })
+      expect(emit).toHaveBeenCalledWith('update:modelValue', 'CA')
+    })
+
+    it('selectedValue still contains the full option objects', () => {
+      const { selectedValue } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
+        reduce: (opt: any) => opt.code,
+        modelValue: 'CA',
+      })
+      expect(selectedValue.value).toEqual([{ label: 'Canada', code: 'CA' }])
+    })
+
+    it('handles reduced multi-select values', () => {
+      const { selectedValue } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
+        reduce: (opt: any) => opt.code,
+        multiple: true,
+        modelValue: ['CA', 'US'],
+      })
+      expect(selectedValue.value).toEqual([
+        { label: 'Canada', code: 'CA' },
+        { label: 'USA', code: 'US' },
+      ])
+    })
+
+    it('isOptionSelected works with reduced values', () => {
+      const { isOptionSelected } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }],
+        reduce: (opt: any) => opt.code,
+        modelValue: 'CA',
+      })
+      expect(isOptionSelected({ label: 'Canada', code: 'CA' })).toBe(true)
+    })
+
+    it('deselect works with reduced values in multi mode', () => {
+      const { deselect, emit } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
+        reduce: (opt: any) => opt.code,
+        multiple: true,
+        modelValue: ['CA', 'US'],
+      })
+      deselect({ label: 'Canada', code: 'CA' })
+      expect(emit).toHaveBeenCalledWith('update:modelValue', ['US'])
+    })
+
+    it('clearSelection emits null (single) or empty array (multi) with reduce', () => {
+      const { clearSelection, emit } = createComboBox({
+        options: [{ label: 'Canada', code: 'CA' }],
+        reduce: (opt: any) => opt.code,
+        modelValue: 'CA',
+      })
+      clearSelection()
+      expect(emit).toHaveBeenCalledWith('update:modelValue', null)
+    })
+  })
+
 })

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useComboBox } from '@/hooks/useComboBox'
+
+function createComboBox(overrides = {}) {
+  const emit = vi.fn()
+  const props = {
+    options: ['one', 'two', 'three'],
+    ...overrides,
+  }
+  return { ...useComboBox(props, emit), emit }
+}
+
+describe('useComboBox', () => {
+  describe('open state', () => {
+    it('starts closed by default', () => {
+      const { open } = createComboBox()
+      expect(open.value).toBe(false)
+    })
+
+    it('toggleOpen flips the state', () => {
+      const { open, toggleOpen } = createComboBox()
+      toggleOpen()
+      expect(open.value).toBe(true)
+      toggleOpen()
+      expect(open.value).toBe(false)
+    })
+
+    it('setOpen sets the state directly', () => {
+      const { open, setOpen } = createComboBox()
+      setOpen(true)
+      expect(open.value).toBe(true)
+      setOpen(false)
+      expect(open.value).toBe(false)
+    })
+
+    it('emits open/close events', () => {
+      const { toggleOpen, emit } = createComboBox()
+      toggleOpen()
+      expect(emit).toHaveBeenCalledWith('open')
+      toggleOpen()
+      expect(emit).toHaveBeenCalledWith('close')
+    })
+  })
+
+  describe('search state', () => {
+    it('starts with empty search', () => {
+      const { search } = createComboBox()
+      expect(search.value).toBe('')
+    })
+
+    it('setSearch updates search text', () => {
+      const { search, setSearch } = createComboBox()
+      setSearch('hello')
+      expect(search.value).toBe('hello')
+    })
+
+    it('isSearching reflects search state', () => {
+      const { isSearching, setSearch } = createComboBox()
+      expect(isSearching.value).toBe(false)
+      setSearch('hello')
+      expect(isSearching.value).toBe(true)
+    })
+  })
+
+  describe('selection - single', () => {
+    it('starts with empty selection when no modelValue', () => {
+      const { selectedValue, isValueEmpty } = createComboBox()
+      expect(selectedValue.value).toEqual([])
+      expect(isValueEmpty.value).toBe(true)
+    })
+
+    it('select sets the value and emits update:modelValue', () => {
+      const { select, emit } = createComboBox()
+      select('one')
+      expect(emit).toHaveBeenCalledWith('update:modelValue', 'one')
+    })
+
+    it('select emits option:selecting and option:selected events', () => {
+      const { select, emit } = createComboBox()
+      select('one')
+      expect(emit).toHaveBeenCalledWith('option:selecting', 'one')
+      expect(emit).toHaveBeenCalledWith('option:selected', 'one')
+    })
+
+    it('clearSelection resets to null and emits', () => {
+      const { clearSelection, emit } = createComboBox({ modelValue: 'one' })
+      clearSelection()
+      expect(emit).toHaveBeenCalledWith('update:modelValue', null)
+    })
+  })
+
+  describe('selection - multiple', () => {
+    it('select appends to existing values', () => {
+      const { select, emit } = createComboBox({
+        multiple: true,
+        modelValue: ['one'],
+      })
+      select('two')
+      expect(emit).toHaveBeenCalledWith('update:modelValue', ['one', 'two'])
+    })
+
+    it('deselect removes from existing values', () => {
+      const { deselect, emit } = createComboBox({
+        multiple: true,
+        modelValue: ['one', 'two'],
+      })
+      deselect('one')
+      expect(emit).toHaveBeenCalledWith('option:deselecting', 'one')
+      expect(emit).toHaveBeenCalledWith('update:modelValue', ['two'])
+      expect(emit).toHaveBeenCalledWith('option:deselected', 'one')
+    })
+
+    it('clearSelection resets to empty array', () => {
+      const { clearSelection, emit } = createComboBox({
+        multiple: true,
+        modelValue: ['one', 'two'],
+      })
+      clearSelection()
+      expect(emit).toHaveBeenCalledWith('update:modelValue', [])
+    })
+  })
+
+  describe('option helpers', () => {
+    it('getOptionLabel returns the option for strings', () => {
+      const { getOptionLabel } = createComboBox()
+      expect(getOptionLabel('hello')).toBe('hello')
+    })
+
+    it('getOptionLabel returns option[label] for objects', () => {
+      const { getOptionLabel } = createComboBox({ label: 'name' })
+      expect(getOptionLabel({ name: 'Canada' })).toBe('Canada')
+    })
+
+    it('getOptionKey returns JSON.stringify by default', () => {
+      const { getOptionKey } = createComboBox()
+      expect(getOptionKey('hello')).toBe(JSON.stringify('hello'))
+    })
+
+    it('getOptionKey returns option.id if present', () => {
+      const { getOptionKey } = createComboBox()
+      expect(getOptionKey({ id: 42, label: 'x' })).toBe('42')
+    })
+
+    it('isOptionSelected returns true for selected options', () => {
+      const { isOptionSelected } = createComboBox({ modelValue: 'one' })
+      expect(isOptionSelected('one')).toBe(true)
+      expect(isOptionSelected('two')).toBe(false)
+    })
+
+    it('isOptionSelectable defaults to true', () => {
+      const { isOptionSelectable } = createComboBox()
+      expect(isOptionSelectable('one')).toBe(true)
+    })
+
+    it('isOptionSelectable respects selectable prop', () => {
+      const { isOptionSelectable } = createComboBox({
+        selectable: (opt: string) => opt !== 'two',
+      })
+      expect(isOptionSelectable('one')).toBe(true)
+      expect(isOptionSelectable('two')).toBe(false)
+    })
+  })
+})

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -160,4 +160,66 @@ describe('useComboBox', () => {
       expect(isOptionSelectable('two')).toBe(false)
     })
   })
+
+  describe('filtering', () => {
+    it('filteredOptions returns all options when search is empty', () => {
+      const { filteredOptions } = createComboBox({ options: ['one', 'two', 'three'] })
+      expect(filteredOptions.value).toEqual(['one', 'two', 'three'])
+    })
+
+    it('filteredOptions filters by search text (case-insensitive)', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: ['One', 'Two', 'Three'],
+      })
+      setSearch('tw')
+      expect(filteredOptions.value).toEqual(['Two'])
+    })
+
+    it('does not filter when filterable is false', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: ['one', 'two', 'three'],
+        filterable: false,
+      })
+      setSearch('tw')
+      expect(filteredOptions.value).toEqual(['one', 'two', 'three'])
+    })
+
+    it('uses custom filter function when provided', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: ['one', 'two', 'three'],
+        filter: (opts: string[], search: string) => opts.filter((o) => o === search),
+      })
+      setSearch('two')
+      expect(filteredOptions.value).toEqual(['two'])
+    })
+
+    it('uses custom filterBy when provided', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: [{ label: 'one', code: '1' }, { label: 'two', code: '2' }],
+        label: 'label',
+        filterBy: (option: any, label: string, search: string) => option.code.includes(search),
+      })
+      setSearch('2')
+      expect(filteredOptions.value).toEqual([{ label: 'two', code: '2' }])
+    })
+
+    it('filteredOptions includes taggable option when taggable and search has no match', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: ['one', 'two'],
+        taggable: true,
+      })
+      setSearch('new-tag')
+      expect(filteredOptions.value).toContain('new-tag')
+    })
+
+    it('filteredOptions does not include duplicate tag when option already exists', () => {
+      const { filteredOptions, setSearch } = createComboBox({
+        options: ['one', 'two'],
+        taggable: true,
+      })
+      setSearch('one')
+      const count = filteredOptions.value.filter((o) => o === 'one').length
+      expect(count).toBe(1)
+    })
+  })
 })

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -222,4 +222,85 @@ describe('useComboBox', () => {
       expect(count).toBe(1)
     })
   })
+
+  describe('typeAheadPointer', () => {
+    it('starts at -1', () => {
+      const { typeAheadPointer } = createComboBox()
+      expect(typeAheadPointer.value).toBe(-1)
+    })
+
+    it('typeAheadDown moves to the next selectable option', () => {
+      const { typeAheadPointer, typeAheadDown } = createComboBox({
+        options: ['one', 'two', 'three'],
+      })
+      typeAheadDown()
+      expect(typeAheadPointer.value).toBe(0)
+      typeAheadDown()
+      expect(typeAheadPointer.value).toBe(1)
+    })
+
+    it('typeAheadDown wraps to beginning', () => {
+      const { typeAheadPointer, typeAheadDown } = createComboBox({
+        options: ['one', 'two'],
+      })
+      typeAheadDown() // 0
+      typeAheadDown() // 1
+      typeAheadDown() // wraps to 0
+      expect(typeAheadPointer.value).toBe(0)
+    })
+
+    it('typeAheadDown skips non-selectable options', () => {
+      const { typeAheadPointer, typeAheadDown } = createComboBox({
+        options: ['one', 'two', 'three'],
+        selectable: (opt: string) => opt !== 'two',
+      })
+      typeAheadDown() // 0 (one)
+      typeAheadDown() // skips 1 (two), lands on 2 (three)
+      expect(typeAheadPointer.value).toBe(2)
+    })
+
+    it('typeAheadUp moves to the previous selectable option', () => {
+      const { typeAheadPointer, typeAheadDown, typeAheadUp } = createComboBox({
+        options: ['one', 'two', 'three'],
+      })
+      typeAheadDown() // 0
+      typeAheadDown() // 1
+      typeAheadUp()   // 0
+      expect(typeAheadPointer.value).toBe(0)
+    })
+
+    it('typeAheadUp wraps to end', () => {
+      const { typeAheadPointer, typeAheadUp } = createComboBox({
+        options: ['one', 'two', 'three'],
+      })
+      typeAheadUp() // wraps to 2
+      expect(typeAheadPointer.value).toBe(2)
+    })
+
+    it('typeAheadSelect selects the highlighted option', () => {
+      const { typeAheadDown, typeAheadSelect, emit } = createComboBox({
+        options: ['one', 'two'],
+      })
+      typeAheadDown() // highlight 'one'
+      typeAheadSelect()
+      expect(emit).toHaveBeenCalledWith('update:modelValue', 'one')
+    })
+
+    it('typeAheadSelect does nothing when pointer is -1', () => {
+      const { typeAheadSelect, emit } = createComboBox({
+        options: ['one', 'two'],
+      })
+      typeAheadSelect()
+      expect(emit).not.toHaveBeenCalledWith('update:modelValue', expect.anything())
+    })
+
+    it('isOptionHighlighted returns true for the highlighted index', () => {
+      const { typeAheadDown, isOptionHighlighted } = createComboBox({
+        options: ['one', 'two'],
+      })
+      typeAheadDown()
+      expect(isOptionHighlighted(0)).toBe(true)
+      expect(isOptionHighlighted(1)).toBe(false)
+    })
+  })
 })

--- a/tests/unit/hooks/useComboBox.spec.ts
+++ b/tests/unit/hooks/useComboBox.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { useComboBox } from '@/hooks/useComboBox'
+import type { OptionValue } from '@/types'
 
 function createComboBox(overrides = {}) {
   const emit = vi.fn()
@@ -197,7 +198,7 @@ describe('useComboBox', () => {
       const { filteredOptions, setSearch } = createComboBox({
         options: [{ label: 'one', code: '1' }, { label: 'two', code: '2' }],
         label: 'label',
-        filterBy: (option: any, label: string, search: string) => option.code.includes(search),
+        filterBy: (option: OptionValue, _label: string, search: string) => (option as Record<string, unknown>).code === search,
       })
       setSearch('2')
       expect(filteredOptions.value).toEqual([{ label: 'two', code: '2' }])
@@ -308,7 +309,7 @@ describe('useComboBox', () => {
     it('emits the reduced value on select', () => {
       const { select, emit } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
       })
       select({ label: 'Canada', code: 'CA' })
       expect(emit).toHaveBeenCalledWith('update:modelValue', 'CA')
@@ -317,7 +318,7 @@ describe('useComboBox', () => {
     it('selectedValue still contains the full option objects', () => {
       const { selectedValue } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
         modelValue: 'CA',
       })
       expect(selectedValue.value).toEqual([{ label: 'Canada', code: 'CA' }])
@@ -326,7 +327,7 @@ describe('useComboBox', () => {
     it('handles reduced multi-select values', () => {
       const { selectedValue } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
         multiple: true,
         modelValue: ['CA', 'US'],
       })
@@ -339,7 +340,7 @@ describe('useComboBox', () => {
     it('isOptionSelected works with reduced values', () => {
       const { isOptionSelected } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
         modelValue: 'CA',
       })
       expect(isOptionSelected({ label: 'Canada', code: 'CA' })).toBe(true)
@@ -348,7 +349,7 @@ describe('useComboBox', () => {
     it('deselect works with reduced values in multi mode', () => {
       const { deselect, emit } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }, { label: 'USA', code: 'US' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
         multiple: true,
         modelValue: ['CA', 'US'],
       })
@@ -359,7 +360,7 @@ describe('useComboBox', () => {
     it('clearSelection emits null (single) or empty array (multi) with reduce', () => {
       const { clearSelection, emit } = createComboBox({
         options: [{ label: 'Canada', code: 'CA' }],
-        reduce: (opt: any) => opt.code,
+        reduce: (opt: OptionValue) => (opt as Record<string, unknown>).code,
         modelValue: 'CA',
       })
       clearSelection()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   build: {
     target: 'es2015',
     lib: {
-      entry: resolve(__dirname, 'src/index.js'),
+      entry: resolve(__dirname, 'src/index.ts'),
       name: 'vue-select',
       fileName: (format) => `vue-select.${format}.js`,
     },


### PR DESCRIPTION
## Summary

Headless ComboBox primitives for v4 — the foundation for the new `VueSelect` styled wrapper. **15 commits, all new work.**

### What's new

- **`useComboBox` composable** — core state management: open/close, selection (single + multi), filtering, keyboard nav, typeAhead, reduce, tagging, pushTags, loading
- **`useClickAway` bug fix** — handler reference wasn't stored, so `removeEventListener` was a no-op
- **Types** — `ComboBoxProps`, `ComboBoxContext`, `OptionValue`, `ModelValue` in `src/types.ts`
- **6 primitive components** (all renderless, provide/inject via `ComboBoxKey`):
  - `ComboBox` — root provider, wires up `useComboBox`
  - `ComboBoxInput` — search input with full keyboard nav, ARIA, IME support
  - `ComboBoxMenu` — ARIA listbox with auto-scroll
  - `ComboBoxOption` — highlight, disabled, ARIA option states
  - `ComboBoxButton` — toggle trigger
  - `ComboBoxClear` — clear selection
- **Package exports** — named exports for all primitives + `useComboBox`, default export remains `Select.vue`
- **Tests** — 276 total (unit tests for each component/hook + integration test)

## Test plan

- [x] `npx vitest run --environment jsdom` — 276 tests passing
- [ ] Manual review of ARIA attributes and keyboard navigation
- [ ] Review prop surface for anything that should be dropped before styled wrapper